### PR TITLE
Don't add rawFileKey to models.Recording.userGetAttributes

### DIFF
--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -273,8 +273,6 @@ module.exports = (app, baseUrl) => {
 
         // Make sequelize query.
         var userGroupIds = await request.user.getGroupsIds();
-        var attributes = models.Recording.userGetAttributes;
-        attributes.push("rawFileKey");
         var query = {
           where: {
             "$and": [
@@ -286,7 +284,7 @@ module.exports = (app, baseUrl) => {
             { model: models.Tag, },
             { model: models.Device, where: {}, attributes: ["devicename", "id"] },
           ],
-          attributes: attributes,
+          attributes: models.Recording.userGetAttributes.concat(['rawFileKey']),
         };
 
         // Query database.


### PR DESCRIPTION
The recordings/get/:id API was unintentionally modifying the global model.Recording.userGetAttributes list. This was causing rawFileKey to be added to unrelated queries. After enough calls to this API the list of requested columns became so large the query column limit was reached causing the DB to reject them.