### PR TITLE
Allow users to have direct access to devices

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,8 +12,7 @@ rules:
     - error
     - unix
   quotes:
-    - error
-    - single
+    - off
   semi:
     - error
     - always

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -101,22 +101,13 @@ module.exports = function(app, baseUrl) {
           if (!requestUtil.isFromAUser(request))
             return responseUtil.notFromAUser(response);
 
-          var deviceIds = await request.user.getDeviceIds();
-          var userGroupIds = await request.user.getGroupsIds();
-          var devices = await models.Device.findAndCount({
-            where: { "$or": [
-              {GroupId: {"$in": userGroupIds}},
-              {id: {"$in": deviceIds}},
-            ]},
-            attributes: ["devicename", "id"],
-            order: ['devicename'],
-          });
+          var devices = await models.Device.allForUser(request.user);
 
           return responseUtil.send(response, {
+              devices: devices,
               statusCode: 200,
               success: true,
               messages: ["completed get devices query"],
-              devices: devices,
           })
       });
 };

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -101,11 +101,15 @@ module.exports = function(app, baseUrl) {
           if (!requestUtil.isFromAUser(request))
             return responseUtil.notFromAUser(response);
 
+          var deviceIds = await request.user.getDeviceIds();
           var userGroupIds = await request.user.getGroupsIds();
           var devices = await models.Device.findAndCount({
-              where: { GroupId: { "$in": userGroupIds } },
-              attributes: ["devicename", "id"],
-              order: ['devicename'],
+            where: { "$or": [
+              {GroupId: {"$in": userGroupIds}},
+              {id: {"$in": deviceIds}},
+            ]},
+            attributes: ["devicename", "id"],
+            order: ['devicename'],
           });
 
           return responseUtil.send(response, {

--- a/migrations/20171122123700-add-deviceusers.js
+++ b/migrations/20171122123700-add-deviceusers.js
@@ -1,0 +1,19 @@
+var util = require('../models/util/util');
+
+module.exports = {
+  up: async function(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('Devices', 'UserId');
+    await queryInterface.createTable('DeviceUsers', {
+      admin: { type: Sequelize.BOOLEAN, defaultValue: false },
+      createdAt: { type: Sequelize.DATE, allowNull: false },
+      updatedAt: { type: Sequelize.DATE, allowNull: false },
+    });
+    await util.addSerial(queryInterface, 'DeviceUsers');
+    return util.belongsToMany(queryInterface, 'DeviceUsers', 'Devices', 'Users');
+  },
+
+  down: async function(queryInterface, Sequelize) {
+    await queryInterface.dropTable('DeviceUsers');
+    return queryInterface.addColumn('Devices', 'UserId', {type: Sequelize.INTEGER});
+  }
+};

--- a/models/Device.js
+++ b/models/Device.js
@@ -30,10 +30,26 @@ module.exports = function(sequelize, DataTypes) {
     },
   };
 
+  var allForUser = async function(user) {
+    var deviceIds = await user.getDeviceIds();
+    var userGroupIds = await user.getGroupsIds();
+    console.log("deviceIds", deviceIds);
+    console.log("userGroupIds", userGroupIds);
+    return this.findAndCount({
+      where: { "$or": [
+        {GroupId: {"$in": userGroupIds}},
+        {id: {"$in": deviceIds}},
+      ]},
+      attributes: ["devicename", "id"],
+      order: ['devicename'],
+    });
+  }
+
   var options = {
     classMethods: {
       addAssociations: addAssociations,
       apiSettableFields: apiSettableFields,
+      allForUser: allForUser,
       freeDevicename: freeDevicename
     },
     instanceMethods: {
@@ -82,7 +98,7 @@ function addAssociations(models) {
   models.Device.hasMany(models.IrVideoRecording);
   models.Device.hasMany(models.AudioRecording);
   models.Device.hasMany(models.Recording);
-  models.Group.belongsToMany(models.User, { through: models.DeviceUsers });
+  models.Device.belongsToMany(models.User, { through: models.DeviceUsers });
 }
 
 function afterValidate(device) {

--- a/models/Device.js
+++ b/models/Device.js
@@ -1,7 +1,5 @@
 var bcrypt = require('bcrypt');
 
-var Device;
-
 module.exports = function(sequelize, DataTypes) {
   var name = 'Device';
 
@@ -84,6 +82,7 @@ function addAssociations(models) {
   models.Device.hasMany(models.IrVideoRecording);
   models.Device.hasMany(models.AudioRecording);
   models.Device.hasMany(models.Recording);
+  models.Group.belongsToMany(models.User, { through: models.DeviceUsers });
 }
 
 function afterValidate(device) {

--- a/models/Device.js
+++ b/models/Device.js
@@ -33,8 +33,6 @@ module.exports = function(sequelize, DataTypes) {
   var allForUser = async function(user) {
     var deviceIds = await user.getDeviceIds();
     var userGroupIds = await user.getGroupsIds();
-    console.log("deviceIds", deviceIds);
-    console.log("userGroupIds", userGroupIds);
     return this.findAndCount({
       where: { "$or": [
         {GroupId: {"$in": userGroupIds}},

--- a/models/DeviceUsers.js
+++ b/models/DeviceUsers.js
@@ -1,0 +1,18 @@
+module.exports = function(sequelize, DataTypes) {
+  var name = 'DeviceUsers';
+
+  var attributes = {
+    admin: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+  };
+
+  var options = {
+    classMethods: {
+      addAssociations: function() {}
+    },
+  };
+
+  return sequelize.define(name, attributes, options);
+};

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -58,7 +58,7 @@ module.exports = function(sequelize, DataTypes) {
 
 /**
  * Returns JSON describing what the user can do to the recording.
- * Premission types: DELETE, TAG, VIEW,
+ * Permission types: DELETE, TAG, VIEW,
  * //TODO This will be edited in the future when recordings can be public.
  */
 function getUserPermissions(user) {

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -51,7 +51,7 @@ module.exports = function(sequelize, DataTypes) {
     if (taggedOnly == true) {
       tagRequired = true;
     } else if (taggedOnly == false) {
-      sqlLiteral = 'NOT EXISTS (SELECT * FROM   "Tags" WHERE  "Tags".id = "Recording".id)';
+      sqlLiteral = 'NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id)';
       tagRequired = false;
     }
 

--- a/models/User.js
+++ b/models/User.js
@@ -32,6 +32,7 @@ module.exports = function(sequelize, DataTypes) {
     instanceMethods: {
       comparePassword: comparePassword,
       getGroupsIds: getGroupsIds,
+      getDeviceIds: getDeviceIds,
       getJwtDataValues: getJwtDataValues,
       getDataValues: getDataValues
     },
@@ -80,7 +81,16 @@ function getGroupsIds() {
   return this.getGroups()
     .then(function(groups) {
       var idList = [];
-      for (var key in groups) { idList.push(groups[key].dataValues.id); }
+      for (var key in groups) { idList.push(groups[key].id); }
+      return idList;
+    });
+}
+
+function getDeviceIds() {
+  return this.getDevices()
+    .then(function(devices) {
+      var idList = [];
+      for (var key in devices) { idList.push(devices[key].id); }
       return idList;
     });
 }

--- a/models/User.js
+++ b/models/User.js
@@ -72,8 +72,8 @@ function getDataValues() {
 }
 
 function addAssociations(models) {
-  models.User.hasMany(models.Device);
   models.User.belongsToMany(models.Group, { through: models.GroupUsers });
+  models.User.belongsToMany(models.Device, { through: models.DeviceUsers });
 }
 
 function getGroupsIds() {


### PR DESCRIPTION
In some cases it's useful to be able to give a user access to a device's recordings when using group membership is cumbersome. This change introduces a new DeviceUsers table which allows users to access devices. The pre-existing (unused)  user(1) : device(M) association has been removed.

This change also moves all the recording query logic into the model where it should be. This makes it easier to share query functionality between the query and "just get one" aspects.

Still to do:
- [x] Fix the tagged/not tagged bug 
- [x] Update the code that retrieves the devices for the dropdown to include devices accessible via DeviceUsers