### PR TITLE
User & group management APIs

### DIFF
--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -78,7 +78,7 @@ module.exports = function(app, baseUrl) {
    * @apiGroup Group
    *
    * @apiParam {JSON} where [Sequelize where conditions](http://docs.sequelizejs.com/manual/tutorial/querying.html#where) for query.
-   * @apiParam {Number} userId Only get groups that this user belongs to.
+   * @apiParam {Number} [userId] Only get groups that this user belongs to.
    *
    * @apiUse V1ResponseSuccess
    *
@@ -101,13 +101,18 @@ module.exports = function(app, baseUrl) {
         });
       }
 
+      var userWhere = null;
+      if (queryUserId != null) {
+        userWhere = { id: queryUserId };
+      }
+
       var groups = await models.Group.findAll({
         where: where,
         include: [
           {
             model: models.User,
             attributes: ['id', 'username'],
-            where: {"id": queryUserId}
+            where: userWhere,
           },
         ],
       });

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -163,7 +163,7 @@ module.exports = function(app, baseUrl) {
   );
 
   /**
-  * @api {post} /api/v1/groups/users Removes a user from a group.
+  * @api {delete} /api/v1/groups/users Removes a user from a group.
   * @apiName RemoveUserFromGroup
   * @apiGroup Group
   * @apiDescription This call can remove a user from a group. Has to be authenticated

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -5,6 +5,8 @@ var config = require('../../config/config');
 var passport = require('passport');
 var responseUtil = require('./responseUtil');
 require('../../passportConfig')(passport);
+var log = require('../../logging');
+var requestUtil = require('./requestUtil');
 
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/groups';
@@ -69,4 +71,138 @@ module.exports = function(app, baseUrl) {
         }
       });
   });
+
+  /**
+   * @api {get} /api/v1/groups Get groups
+   * @apiName GetGroups
+   * @apiGroup Group
+   *
+   * @apiParam {JSON} where [Sequelize where conditions](http://docs.sequelizejs.com/manual/tutorial/querying.html#where) for query.
+   *
+   * @apiUse V1ResponseSuccess
+   *
+   * @apiUse V1ResponseError
+   */
+  app.get(
+    apiUrl,
+    async function(request, response) {
+      log.info(request.method + ' Request: ' + request.url);
+
+      var where = request.query.where;
+      try {
+        where = JSON.parse(where);
+      } catch (e) {
+        return responseUtil.send(response, {
+          statusCode: 400,
+          success: false,
+          messages: ['Could not parse "where" to a JSON'],
+        });
+      }
+
+      var groups = await models.Group.findAll({where: where});
+      return responseUtil.send(response, {
+        statusCode: 200,
+        success: false,
+        messages: [],
+        groups: groups,
+      });
+    }
+  );
+
+  /**
+  * @api {post} /api/v1/groups/users Add a user to a group.
+  * @apiName AddUserToGroup
+  * @apiGroup Group
+  * @apiDescription This call can add a user to a group. Has to be authenticated
+  * by an admin from the group or a superuser. It can also be used to update the
+  * admin status of a user for the group by setting admin to true or false.
+  *
+  * @apiUse V1UserAuthorizationHeader
+  *
+  * @apiParam {Number} groupId ID of the group.
+  * @apiParam {Number} userId ID of the user to add to the grouop.
+  * @apiParam {Boolean} admin If the user should be an admin for the group.
+  *
+  * @apiUse V1ResponseSuccess
+  * @apiUse V1ResponseError
+  */
+  app.post(
+    apiUrl + '/users',
+    passport.authenticate(['jwt'], { session: false }),
+    async function (request, response) {
+      log.info(request.method + ' Request: ' + request.url);
+
+      if (!requestUtil.isFromAUser(request)) {
+        return responseUtil.notFromAUser(response);
+      }
+
+      var added = await models.Group.addUserToGroup(
+        request.user,
+        request.body.groupId,
+        request.body.userId,
+        request.body.admin
+      );
+
+      if (added) {
+        return responseUtil.send(response, {
+          statusCode: 200,
+          success: true,
+          messages: ['Added user to group'],
+        });
+      } else {
+        return responseUtil.send(response, {
+          statusCode: 400,
+          success: false,
+          messages: ['Failed to add user to group'],
+        });
+      }
+    }
+  );
+
+  /**
+  * @api {post} /api/v1/groups/users Removes a user from a group.
+  * @apiName RemoveUserFromGroup
+  * @apiGroup Group
+  * @apiDescription This call can remove a user from a group. Has to be authenticated
+  * by an admin from the group or a superuser.
+  *
+  * @apiUse V1UserAuthorizationHeader
+  *
+  * @apiParam {Number} groupId ID of the group.
+  * @apiParam {Number} userId ID of the user to remove from the grouop.
+  *
+  * @apiUse V1ResponseSuccess
+  * @apiUse V1ResponseError
+  */
+  app.delete(
+    apiUrl + '/users',
+    passport.authenticate(['jwt'], { session: false }),
+    async function (request, response) {
+      log.info(request.method + ' Request: ' + request.url);
+
+      if (!requestUtil.isFromAUser(request)) {
+        return responseUtil.notFromAUser(response);
+      }
+
+      var removed = await models.Group.removeUserFromGroup(
+        request.user,
+        request.body.groupId,
+        request.body.userId,
+      );
+
+      if (removed) {
+        return responseUtil.send(response, {
+          statusCode: 200,
+          success: true,
+          messages: ['Removed user from the group'],
+        });
+      } else {
+        return responseUtil.send(response, {
+          statusCode: 400,
+          success: false,
+          messages: ['Failed to remove user from the group'],
+        });
+      }
+    }
+  );
 };

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -99,7 +99,10 @@ module.exports = function(app, baseUrl) {
         });
       }
 
-      var groups = await models.Group.findAll({where: where});
+      var groups = await models.Group.findAll({
+        where: where,
+        include: [{ model: models.User, attributes: ['id', 'username'] }],
+      });
       return responseUtil.send(response, {
         statusCode: 200,
         success: false,

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -101,21 +101,8 @@ module.exports = function(app, baseUrl) {
         });
       }
 
-      var userWhere = null;
-      if (queryUserId != null) {
-        userWhere = { id: queryUserId };
-      }
+      var groups = await models.Group.query(where, queryUserId);
 
-      var groups = await models.Group.findAll({
-        where: where,
-        include: [
-          {
-            model: models.User,
-            attributes: ['id', 'username'],
-            where: userWhere,
-          },
-        ],
-      });
       return responseUtil.send(response, {
         statusCode: 200,
         success: false,

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -78,6 +78,7 @@ module.exports = function(app, baseUrl) {
    * @apiGroup Group
    *
    * @apiParam {JSON} where [Sequelize where conditions](http://docs.sequelizejs.com/manual/tutorial/querying.html#where) for query.
+   * @apiParam {Number} userId Only get groups that this user belongs to.
    *
    * @apiUse V1ResponseSuccess
    *
@@ -89,6 +90,7 @@ module.exports = function(app, baseUrl) {
       log.info(request.method + ' Request: ' + request.url);
 
       var where = request.query.where;
+      var queryUserId = request.query.userId;
       try {
         where = JSON.parse(where);
       } catch (e) {
@@ -101,7 +103,13 @@ module.exports = function(app, baseUrl) {
 
       var groups = await models.Group.findAll({
         where: where,
-        include: [{ model: models.User, attributes: ['id', 'username'] }],
+        include: [
+          {
+            model: models.User,
+            attributes: ['id', 'username'],
+            where: {"id": queryUserId}
+          },
+        ],
       });
       return responseUtil.send(response, {
         statusCode: 200,

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -258,7 +258,7 @@ module.exports = (app, baseUrl) => {
           downloadRawData = {
             _type: 'fileDownload',
             key: recording.rawFileKey,
-            filename: "rawData",
+            filename: recording.getRawFileName(),
             mimeType: null,
           };
         }
@@ -327,19 +327,19 @@ module.exports = (app, baseUrl) => {
   * @api {patch} /api/v1/recordings/:id Update an existing recording
   * @apiName UpdateRecording
   * @apiGroup Recordings
-  * @apiDescription This call is used for updating fields of a
-  * previously submitted recording.
+  * @apiDescription This call is used for updating fields of a previously
+  * submitted recording.
   *
-  * The following fields may be updated:
+  * The following fields that may be updated are:
   * - location
   * - comment
-  * If a change to any other field is attempted the request will fail
-  * and no update will occur.
+  *
+  * If a change to any other field is attempted the request will fail and no
+  * update will occur.
   *
   * @apiUse V1UserAuthorizationHeader
   *
-  * @apiParam {JSON} updates Object containing the fields to update
-  * and their new values.
+  * @apiParam {JSON} updates Object containing the fields to update and their new values.
   *
   * @apiUse V1ResponseSuccess
   * @apiUse V1ResponseError

--- a/migrations/20171201023936-add-superuser.js
+++ b/migrations/20171201023936-add-superuser.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async function (queryInterface, Sequelize) {
+    return await queryInterface.addColumn(
+      'Users', 'superuser', {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false,
+      });
+  },
+
+  down: async function (queryInterface, Sequelize) {
+    return await queryInterface.removeColumn('Users', 'superuser');
+  }
+};

--- a/models/Group.js
+++ b/models/Group.js
@@ -15,7 +15,8 @@ module.exports = function(sequelize, DataTypes) {
    */
   var addUserToGroup = async function(groupAdmin, groupId, userToAddId, admin) {
     // Return false if the user doesn't have permission.
-    if (!groupAdmin.superuser && !models.GroupUsers.isAdmin(groupId, groupAdmin.id)) {
+    const isAdmin = await models.GroupUsers.isAdmin(groupId, groupAdmin.id);
+    if (groupAdmin.superuser != true && isAdmin != true) {
       return false;
     }
 
@@ -50,7 +51,8 @@ module.exports = function(sequelize, DataTypes) {
    */
   var removeUserFromGroup = async function(groupAdmin, groupId, userToRemoveId) {
     // Return false if the user doesn't have permission.
-    if (!groupAdmin.superuser && !models.GroupUsers.isAdmin(groupId, groupAdmin.id)) {
+    const isAdmin = await models.GroupUsers.isAdmin(groupId, groupAdmin.id);
+    if (groupAdmin.superuser != true && isAdmin != true) {
       return false;
     }
 

--- a/models/Group.js
+++ b/models/Group.js
@@ -79,6 +79,29 @@ module.exports = function(sequelize, DataTypes) {
     return true;
   };
 
+  /**
+   * Return one or more groups matching the where condition. UserId can be used
+   * to just get groups from that user.
+   */
+  const query = async function(where, userId) {
+
+    var userWhere = null;
+    if (userId != null) {
+      userWhere = { id: userId };
+    }
+
+    return await models.Group.findAll({
+      where: where,
+      include: [
+        {
+          model: models.User,
+          attributes: ['id', 'username'],
+          where: userWhere,
+        },
+      ],
+    });
+  };
+
   var options = {
     classMethods: {
       addAssociations: addAssociations,
@@ -86,6 +109,7 @@ module.exports = function(sequelize, DataTypes) {
       getIdFromName: getIdFromName,
       addUserToGroup: addUserToGroup,
       removeUserFromGroup: removeUserFromGroup,
+      query: query,
     },
   };
 

--- a/models/Group.js
+++ b/models/Group.js
@@ -7,12 +7,84 @@ module.exports = function(sequelize, DataTypes) {
     },
   };
 
+  var models = sequelize.models;
+
+  /**
+   * Adds a user to a Group, if the given user has permission to do so.
+   * The user must be a group admin to do this.
+   */
+  var addUserToGroup = async function(groupAdmin, groupId, userToAddId, admin) {
+    // Return false if the user doesn't have permission.
+    if (!groupAdmin.superuser && !models.GroupUsers.isAdmin(groupId, groupAdmin.id)) {
+      return false;
+    }
+
+    var userToAdd = await models.User.findById(userToAddId);
+    var group = await this.findById(groupId);
+
+    if (userToAdd == null || group == null) {
+      return false;
+    }
+
+    // Get association if already there and update it.
+    var groupUser = await models.GroupUsers.findOne({
+      where: {
+        GroupId: groupId,
+        UserId: userToAdd.id,
+      }
+    });
+    if (groupUser != null) {
+      groupUser.admin = admin; // Update admin value.
+      await groupUser.save();
+      console.log('Updated');
+      return true;
+    }
+
+    await group.addUser(userToAdd.id, {admin: admin});
+    return true;
+  };
+
+  /**
+   * Removes a user from a Group, if the given user has permission to do so.
+   * The user must be a group admin to do this.
+   */
+  var removeUserFromGroup = async function(groupAdmin, groupId, userToRemoveId) {
+    // Return false if the user doesn't have permission.
+    if (!groupAdmin.superuser && !models.GroupUsers.isAdmin(groupId, groupAdmin.id)) {
+      return false;
+    }
+
+    var userToRemove = await models.User.findById(userToRemoveId);
+    var group = await this.findById(groupId);
+
+    if (userToRemove == null || group == null) {
+      return false;
+    }
+
+    // Get association if already there and update it.
+    var groupUsers = await models.GroupUsers.findAll({
+      where: {
+        GroupId: groupId,
+        UserId: userToRemove.id,
+      }
+    });
+    if (groupUsers.length == 0) {
+      return false;
+    }
+    for (var i in groupUsers) {
+      await groupUsers[i].destroy();
+    }
+    return true;
+  };
+
   var options = {
     classMethods: {
       addAssociations: addAssociations,
       apiSettableFields: apiSettableFields,
-      getIdFromName: getIdFromName
-    }
+      getIdFromName: getIdFromName,
+      addUserToGroup: addUserToGroup,
+      removeUserFromGroup: removeUserFromGroup,
+    },
   };
 
   return sequelize.define(name, attributes, options);

--- a/models/GroupUsers.js
+++ b/models/GroupUsers.js
@@ -8,9 +8,28 @@ module.exports = function(sequelize, DataTypes) {
     },
   };
 
+  /**
+   * Checks if a user is a admin of a group.
+   */
+  var isAdmin = async function(groupId, userId) {
+    var groupUsers = await this.findOne({
+      where: {
+        GroupId: groupId,
+        UserId: userId,
+        admin: true,
+      }
+    });
+    if (groupUsers == null) {
+      return false;
+    } else {
+      return true;
+    }
+  };
+  
   var options = {
     classMethods: {
       addAssociations: addAssociations,
+      isAdmin: isAdmin,
     },
   };
 

--- a/models/GroupUsers.js
+++ b/models/GroupUsers.js
@@ -19,11 +19,7 @@ module.exports = function(sequelize, DataTypes) {
         admin: true,
       }
     });
-    if (groupUsers == null) {
-      return false;
-    } else {
-      return true;
-    }
+    return groupUsers != null;
   };
   
   var options = {

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -151,6 +151,14 @@ module.exports = function(sequelize, DataTypes) {
     ]};
   };
 
+  var getRawFileName = function() {
+    var ext = '';
+    if (this.type == 'thermalRaw') {
+      ext = '.cptv';
+    }
+    return moment.tz('Pacific/Auckland').format('YYYYMMDD-HHmmss') + ext;
+  };
+
   var options = {
     classMethods: {
       addAssociations: addAssociations,
@@ -166,6 +174,7 @@ module.exports = function(sequelize, DataTypes) {
     instanceMethods: {
       canGetRaw: canGetRaw,
       getFileName: getFileName,
+      getRawFileName: getRawFileName,
       getUserPermissions: getUserPermissions,
     },
   };

--- a/models/User.js
+++ b/models/User.js
@@ -80,6 +80,7 @@ function getDataValues() {
     user.getGroups()
       .then(function(groups) {
         resolve({
+          id: user.getDataValue('id'),
           username: user.getDataValue('username'),
           firstName: user.getDataValue('firstName'),
           lastName: user.getDataValue('lastName'),

--- a/models/User.js
+++ b/models/User.js
@@ -28,17 +28,31 @@ module.exports = function(sequelize, DataTypes) {
     }
   };
 
+  const publicFields = Object.freeze([
+    'id',
+    'username',
+  ]);
+
+  var getAll = async function(where) {
+    return await this.findAll({
+      where: where,
+      attributes: publicFields,
+    });
+  };
+
   var options = {
     classMethods: {
       addAssociations: addAssociations,
-      apiSettableFields: apiSettableFields
+      apiSettableFields: apiSettableFields,
+      getAll: getAll,
     },
     instanceMethods: {
       comparePassword: comparePassword,
       getGroupsIds: getGroupsIds,
       getDeviceIds: getDeviceIds,
       getJwtDataValues: getJwtDataValues,
-      getDataValues: getDataValues
+      getDataValues: getDataValues,
+      getAll: getAll,
     },
     hooks: {
       afterValidate: afterValidate

--- a/models/User.js
+++ b/models/User.js
@@ -22,6 +22,10 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    superuser: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    }
   };
 
   var options = {


### PR DESCRIPTION
closes #39 
API added/changed to help with group admin on web:
- GET /api/v1/groups 
- POST /api/v1/groups/users
- DELETE /api/v1/group/users
- GET /api/v1/users This was changed to take a sequelize 'where' statement so you can get users ID, as users IDs are used when adding, removing users from groups.

Added 'superuser' to users. Adds ability to add/remove users from any group.
