### PR TITLE
Add "no-human" tag mode and supporting querying for specific tags

### DIFF
--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -170,7 +170,21 @@ module.exports = (app, baseUrl) => {
       try {
         where = JSON.parse(where);
       } catch (e) {
-        errorMessages.push("'where' field was not a valid JSON.");
+        errorMessages.push("'where' field was not a valid JSON");
+      }
+
+      var tags = request.query.tags;
+      if (tags) {
+        try {
+          tags = JSON.parse(tags);
+        } catch (e) {
+          errorMessages.push("'tags' field was not a valid JSON");
+        }
+        if (tags !== null && !Array.isArray(tags)) {
+          errorMessages.push("'tags' field does not contain an array");
+        }
+      } else {
+        tags = null;
       }
 
       var offset = parseInt(request.query.offset);
@@ -208,7 +222,7 @@ module.exports = (app, baseUrl) => {
       delete where._tagged; // remove legacy tag mode selector (if included)
 
       var result = await models.Recording.query(
-        request.user, where, tagMode, offset, limit, order);
+        request.user, where, tagMode, tags, offset, limit, order);
 
       return responseUtil.send(response, {
         statusCode: 200,

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -54,6 +54,9 @@ module.exports = function(sequelize, DataTypes) {
     case 'tagged':
       tagLiteral = 'EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id)';
       break;
+    case 'no-human':
+      tagLiteral = `NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)`;
+      break;
     case 'automatic-only':
       tagLiteral = `EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND automatic)
                     AND NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)`;
@@ -312,6 +315,7 @@ const validTagModes = Object.freeze([
   'any',
   'untagged',
   'tagged',
+  'no-human',  // untagged or automatic only
   'automatic-only',
   'human-only',
   'automatic+human',

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -2,7 +2,6 @@ var util = require('./util/util');
 var validation = require('./util/validation');
 var moment = require('moment-timezone');
 
-
 module.exports = function(sequelize, DataTypes) {
   var name = 'Recording';
 
@@ -45,32 +44,7 @@ module.exports = function(sequelize, DataTypes) {
     * Return one or more recordings for a user matching the query
     * arguments given.
     */
-  var query = async function(user, where, tagMode, offset, limit, order) {
-    var tagLiteral = '';
-    switch (tagMode) {
-    case 'untagged':
-      tagLiteral = 'NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id)';
-      break;
-    case 'tagged':
-      tagLiteral = 'EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id)';
-      break;
-    case 'no-human':
-      tagLiteral = `NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)`;
-      break;
-    case 'automatic-only':
-      tagLiteral = `EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND automatic)
-                    AND NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)`;
-      break;
-    case 'human-only':
-      tagLiteral = `EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)
-                    AND NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND automatic)`;
-      break;
-    case 'automatic+human':
-      tagLiteral = `EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND automatic)
-                    AND EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)`;
-      break;
-    }
-
+  var query = async function(user, where, tagMode, tags, offset, limit, order) {
     if (order == null) {
       order = [
         // Sort by recordingDatetime but handle the case of the
@@ -85,13 +59,13 @@ module.exports = function(sequelize, DataTypes) {
         "$and": [
           where, // User query
           await recordingsFor(user),
-          sequelize.literal(tagLiteral),
+          sequelize.literal(handleTagMode(tagMode)),
         ],
       },
       order: order,
       include: [
         { model: models.Group },
-        { model: models.Tag },
+        { model: models.Tag, where: makeTagsWhere(tags) },
         { model: models.Device, where: {}, attributes: ["devicename", "id"] },
       ],
       limit: limit,
@@ -99,6 +73,58 @@ module.exports = function(sequelize, DataTypes) {
       attributes: userGetAttributes,
     };
     return this.findAndCount(q);
+  };
+
+  var handleTagMode = (tagMode) => {
+    switch (tagMode) {
+    case 'any':
+      return '';
+    case 'untagged':
+      return 'NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id)';
+    case 'tagged':
+      return 'EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id)';
+    case 'no-human':
+      return `NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)`;
+    case 'automatic-only':
+      return `EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND automatic)
+              AND NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)`;
+    case 'human-only':
+      return `EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)
+              AND NOT EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND automatic)`;
+    case 'automatic+human':
+      return `EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND automatic)
+              AND EXISTS (SELECT * FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id AND NOT automatic)`;
+    default:
+      throw `invalid tag mode: ${tagMode}`;
+    }
+  };
+
+  var makeTagsWhere = (tags) => {
+    if (!tags || tags.length === 0) {
+      return null;
+    }
+
+    var parts = [];
+    for (var i = 0; i < tags.length; i++) {
+      var tag = tags[i];
+      switch (tag) {
+      case "interesting":
+        parts.push({
+          "$not": {
+            "$or": [
+              {animal: null, event: "false positive"},
+              {animal: "bird"},
+            ]},
+        });
+        break;
+      default:
+        parts.push({animal: tag});
+      }
+    }
+    if (parts.Length == 1) {
+      return parts[0];
+    }
+    return {"$or": parts};
   };
 
   /**


### PR DESCRIPTION
A tag mode of "no-human" returns recordings which are untagged by humans - either not tagged at all or only just automatically tagged.

The recordings query endpoint now accepts a "tags" field which takes an array of tags to match. These are ORed together. A virtual tag type of "interesting" will match tags which are *not* false positive or bird.


