### PR TITLE
Fix audio uploads & various other issues

### DIFF
--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -1,4 +1,3 @@
-const log = require('../../logging');
 const middleware = require('../middleware');
 const models = require('../../models');
 const tagsUtil = require('./tagsUtil');
@@ -42,7 +41,6 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateDevice,
     ],
     middleware.requestWrapper(async (req, res) => {
-      log.info(req.method + " Request: " + req.url);
       return util.addRecordingFromPost(models.AudioRecording, req, res);
     })
   );
@@ -72,7 +70,6 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
     ],
     middleware.requestWrapper(async (req, res) => {
-      log.info(req.method + " Request: " + req.url);
       return util.updateDataFromPut(models.AudioRecording, req, res);
     })
   );
@@ -93,7 +90,6 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
     ],
     middleware.requestWrapper(async (req, res) => {
-      log.info(req.method + " Request: " + req.url);
       return util.deleteDataPoint(models.AudioRecording, req, res);
     })
   );
@@ -123,7 +119,6 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
     ],
     middleware.requestWrapper(async (req, res) => {
-      log.info(req.method + " Request: " + req.url);
       return util.getRecordingsFromModel(models.AudioRecording, req, res);
     })
   );
@@ -149,7 +144,6 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
     ],
     middleware.requestWrapper(async (req, res) => {
-      log.info(req.method + " Request: " + req.url);
       return util.getRecordingFile(models.AudioRecording, req, res);
     })
   );
@@ -160,7 +154,6 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
     ],
     middleware.requestWrapper(async (req, res) => {
-      log.info(req.method + " Request: " + req.url);
       return tagsUtil.add(models.AudioRecording, req, res);
     })
   );
@@ -171,7 +164,6 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
     ],
     middleware.requestWrapper(async (req, res) => {
-      log.info(req.method + " Request: " + req.url);
       return tagsUtil.remove(models.AudioRecording, req, res);
     })
   );
@@ -182,7 +174,6 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
     ],
     middleware.requestWrapper(async (req, res) => {
-      log.info(req.method + " Request: " + req.url);
       return tagsUtil.get(models.AudioRecording, req, res);
     })
   );

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -97,7 +97,7 @@ module.exports = (app, baseUrl) => {
             if (err) {
               return reject(err);
             }
-            log.info("Finished streaming file to LeoFS Key:", key);
+            log.info("Finished streaming file to object store key:", key);
             resolve();
           });
         });

--- a/api/V1/User.js
+++ b/api/V1/User.js
@@ -7,7 +7,6 @@ const middleware   = require('../middleware');
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/users';
 
-
   /**
    * @api {post} /api/v1/users Register a new user
    * @apiName RegisterUser
@@ -67,7 +66,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where'),
+      middleware.parseJSON('where').optional(),
     ],
     middleware.requestWrapper(async (request, response) => {
 

--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -48,17 +48,14 @@ function getRecordingsFromModel(modelClass, request, response) {
  * @param {Object} response - Express response object.
  */
 function addRecordingFromPost(model, request, response) {
-
-  // Check that if the request was authenticated that is was
-  // authenticated by a user JWT, not a device JWT.
-  // TODO get passport to do this...
-  if (request.user !== null && !requestUtil.isFromADevice(request))
-    return responseUtil.notFromADevice(response);
-
-  var device = request.user;
+  var device = request.device;
   var modelClass = model;
   var modelInstance;
   var file;
+
+  if (request.device === null) {
+    throw { badRequest: "expected device" };
+  }
 
   requestUtil
     .getFileAndDataField(request)

--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -4,7 +4,7 @@ var requestUtil = require('./requestUtil');
 var responseUtil = require('./responseUtil');
 
 var INVALID_DATA = 'Invalid data key in body, should be a JSON.';
-var INVALID_ID = 'Invalid ID field. Shoudl be an integer.';
+var INVALID_ID = 'Invalid ID field. Should be an integer.';
 var NO_DATAPOINT_FOUND =
   'No datapoint was found with given ID. make sure that you have permissions ' +
   'to view datapoint.';

--- a/api/middleware.js
+++ b/api/middleware.js
@@ -100,7 +100,7 @@ const getUser   = getModel(models.User, 'user');
 
 const checkNewName = function(field) {
   return check(field, 'invalid name')
-    .isLength({ min: 8 })
+    .isLength({ min: 3 })
     .matches(/^[a-zA-Z0-9]+(?:[_ -]?[a-zA-Z0-9])*$/);
 };
 

--- a/models/Group.js
+++ b/models/Group.js
@@ -118,8 +118,8 @@ module.exports = function(sequelize, DataTypes) {
     return await this.findOne({ where: { groupname: name }});
   };
 
-  const freeGroupname = async function(groupanem) {
-    var group = await this.findOne({where: { groupname: groupanem }});
+  const freeGroupname = async function(name) {
+    var group = await this.findOne({where: { groupname: name }});
     if (group != null) {
       throw new Error('groupname in use');
     }


### PR DESCRIPTION
This PR fixes authentication for audio uploads which was broken by the recent change to use field verification middleware. It also fixes numerous other issues I ran into while troubleshooting.

The root issue was that the `isFromADevice` no longer works with the new middleware in place. It will go away soon anyway.

Other highlights:
* group addition was broken because the User API was requiring a `where` argument
* device and user names now need to be only 3 chars long - 8 was a bit draconian
* various typos fixed

