### PR TITLE
/api/V1/users -> /api/V1/users/:username

### DIFF
--- a/api/V1/AuthenticateDevice.js
+++ b/api/V1/AuthenticateDevice.js
@@ -20,7 +20,7 @@ module.exports = function(app) {
   app.post(
     '/authenticate_device',
     [
-      middleware.getDevice,
+      middleware.getDeviceByName,
       body('password').exists(),
     ],
     middleware.requestWrapper(async (request, response) => {

--- a/api/V1/AuthenticateUser.js
+++ b/api/V1/AuthenticateUser.js
@@ -21,7 +21,7 @@ module.exports = function(app) {
   app.post(
     '/authenticate_user',
     [
-      middleware.getUser,
+      middleware.getUserByName,
       body('password').exists(),
     ],
     middleware.requestWrapper(async (request, response) => {

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -28,7 +28,7 @@ module.exports = function(app, baseUrl) {
       middleware.checkNewName('devicename')
         .custom(value => { return models.Device.freeDevicename(value); }),
       middleware.checkNewPassword('password'),
-      middleware.getGroup,
+      middleware.getGroupByName,
     ],
     middleware.requestWrapper(async (request, response) => {
       const device = await models.Device.create({
@@ -92,8 +92,8 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/users',
     [
       middleware.authenticateUser,
-      middleware.getDevice,
-      middleware.getUser,
+      middleware.getDeviceById,
+      middleware.getUserById,
       check('admin').isIn([true, false]),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -140,8 +140,8 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/users',
     [
       middleware.authenticateUser,
-      middleware.getUser,
-      middleware.getDevice,
+      middleware.getUserById,
+      middleware.getDeviceById,
     ],
     middleware.requestWrapper(async function(request, response) {
       var removed = await models.Device.removeUserFromDevice(

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -92,8 +92,8 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/users',
     [
       middleware.authenticateUser,
-      middleware.getGroup,
-      middleware.getUser,
+      middleware.getGroupById,
+      middleware.getUserById,
       check('admin').isBoolean(),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -139,8 +139,8 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/users',
     [
       middleware.authenticateUser,
-      middleware.getUser,
-      middleware.getGroup,
+      middleware.getUserById,
+      middleware.getGroupById,
     ],
     middleware.requestWrapper(async (request, response) => {
 

--- a/api/V1/User.js
+++ b/api/V1/User.js
@@ -3,6 +3,7 @@ const jwt          = require('jsonwebtoken');
 const config       = require('../../config/config');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
+const check        = require('express-validator/check');
 
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/users';
@@ -49,33 +50,37 @@ module.exports = function(app, baseUrl) {
   );
 
   /**
-   * @api {get} api/v1/users Get users
-   * @apiName GetUsers
+   * @api {get} api/v1/users/:username Get details for a user
+   * @apiName GetUser
    * @apiGroup User
    *
    * @apiUse V1UserAuthorizationHeader
    *
-   * @apiParam {JSON} where [Sequelize where conditions](http://docs.sequelizejs.com/manual/tutorial/querying.html#where) for query.
-   *
-   * @apiSuccess {JSON} usersData List of users.
+   * @apiSuccess {JSON} userData Metadata of the user.
    * @apiUse V1ResponseSuccess
    *
    * @apiUse V1ResponseError
    */
   app.get(
-    apiUrl,
+    apiUrl + "/:username",
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where').optional(),
+      check.param("username").exists(),
     ],
     middleware.requestWrapper(async (request, response) => {
-
-      var users = await models.User.getAll(request.query.where);
+      var user = await models.User.getFromName(request.params.username);
+      if (user === null) {
+        return responseUtil.send(response, {
+          statusCode: 400,
+          success: false,
+          messages: ["no such user"],
+        });
+      }
       return responseUtil.send(response, {
         statusCode: 200,
         success: true,
         messages: [],
-        users: users,
+        userData: await user.getDataValues(),
       });
     })
   );

--- a/api/V1/User.js
+++ b/api/V1/User.js
@@ -65,22 +65,14 @@ module.exports = function(app, baseUrl) {
     apiUrl + "/:username",
     [
       middleware.authenticateUser,
-      check.param("username").exists(),
+      middleware.getUserByName,
     ],
     middleware.requestWrapper(async (request, response) => {
-      var user = await models.User.getFromName(request.params.username);
-      if (user === null) {
-        return responseUtil.send(response, {
-          statusCode: 400,
-          success: false,
-          messages: ["no such user"],
-        });
-      }
       return responseUtil.send(response, {
         statusCode: 200,
         success: true,
         messages: [],
-        userData: await user.getDataValues(),
+        userData: await request.body.user.getDataValues(),
       });
     })
   );

--- a/api/middleware.js
+++ b/api/middleware.js
@@ -68,7 +68,7 @@ const getModelById = function(modelType, fieldName, checkFunc=check) {
     if (model === null) {
       throw new Error(format('could not find %s of %s', fieldName, val));
     }
-    req.body[attrName(modelType)] = model;
+    req.body[modelTypeName(modelType)] = model;
     return true;
   });
 };
@@ -79,22 +79,13 @@ const getModelByName = function(modelType, fieldName, checkFunc=check) {
     if (model === null) {
       throw new Error(format('could not find %s of %s', fieldName, val));
     }
-    req.body[attrName(modelType)] = model;
+    req.body[modelTypeName(modelType)] = model;
     return true;
   });
 };
 
-function attrName(modelType) {
-  switch (modelType) {
-  case models.User:
-    return "user";
-  case models.Group:
-    return "group";
-  case models.Device:
-    return "device";
-  default:
-    throw "unknown model type: " + modelType;
-  }
+function modelTypeName(modelType) {
+  return modelType.options.name.singular.toLowerCase();
 }
 
 const getUserById = getModelById(models.User, 'userId');


### PR DESCRIPTION
Replace the API which returns all the users matching some criteria with one which returns the details for just one username. The latter is the all the web UI actually wants.

It's also good to avoid APIs which take raw sequelize strings as are security risks as and limit our implementation flexibility.

The web UI is being updated to switch to this new API.