### PR TITLE
Log to console only

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,12 @@
 var path = require('path');
 var fs = require('fs');
 
+// Set some default configuration
+var server = {
+  loggerLevel: "info",
+};
+
+
 function loadConfig(configDirPath) {
     console.log(`Looking for config files in directory "${path.resolve(configDirPath)}"`);
 
@@ -34,5 +40,6 @@ function testDatabaseConfigAvailable(config) {
 }
  
 exports.loadConfig = loadConfig;
+exports.server = server;
 
   

--- a/config/app_TEMPLATE.js
+++ b/config/app_TEMPLATE.js
@@ -1,7 +1,6 @@
 // Config instructions: Fill out required fields and save as 'config.js'
 
-// ======= SERVER ==========
-server = { // General server settings
+var server = { // General server settings
   passportSecret: null, // REQUIRED, String. Random string used for passport module for encrypting JWT.
   loggerLevel: "debug", // REQUIRED, one of ('debug', 'warning', 'info', 'error')
   http: {
@@ -10,27 +9,11 @@ server = { // General server settings
   },
 };
 
-// ======= S3 compatible object store settings, e.g. Minio ===========
-s3 = {  // Used for storing audio & video recordings.
-  publicKey: "",  // REQUIRED, String:
-  privateKey: "", // REQUIRED, String
-  bucket: "cacophony",   // REQUIRED, String
-  endpoint: "http://localhost:9000", // REQUIRED, URL
-};
-
-
-// ======= Logging =======
-logging = {
-  folder: "logFiles", // REQUIRED Folder of the logging file.
-}
-
-// ======= File Processing =======
-fileProcessing = {
+var fileProcessing = { // File processing API settings (runs on different port)
   port: 2002,
 };
 
-// ======= Database settings =======
-database = {
+var database = {
   username: "root",
   password: "",
   database: "cacophony",
@@ -38,11 +21,17 @@ database = {
   dialect: "postgres"
 };
 
+var s3 = {  // Used for storing audio & video recordings.
+  publicKey: "",  // REQUIRED, String:
+  privateKey: "", // REQUIRED, String
+  bucket: "cacophony",   // REQUIRED, String
+  endpoint: "http://localhost:9000", // REQUIRED, URL
+};
+
 exports.server = server;
-exports.s3 = s3;
-exports.logging = logging;
 exports.fileProcessing = fileProcessing;
 exports.database = database;
+exports.s3 = s3;
 
 // This is needed because Sequelize looks for development by default when using db:migrate
 exports.development = database;

--- a/logFiles/.gitignore
+++ b/logFiles/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/logging.js
+++ b/logging.js
@@ -1,80 +1,25 @@
 var config = require('./config');
 var winston = require('winston');
 var expressWinston = require('express-winston');
-var path = require('path');
 
-var logger = new(winston.Logger)({
-  transports: [
-    new(winston.transports.File)({
-      name: 'info',
-      filename: path.join(config.logging.folder, 'info.log'),
-      level: 'info'
-    }),
-    new(winston.transports.File)({
-      name: 'debug',
-      filename: path.join(config.logging.folder, 'debug.log'),
-      level: 'debug'
-    }),
-    new(winston.transports.File)({
-      name: 'error',
-      filename: path.join(config.logging.folder, 'error.log'),
-      level: 'error',
-      handleExceptions: true,
-      humanReadableUnhandledException: true
-    }),
-    new(winston.transports.Console)({
-      name: 'console',
-      level: config.server.loggerLevel,
-      colorize: true,
-      handleExceptions: true,
-      humanReadableUnhandledException: true
-    })
-  ]
+var consoleTransport = new(winston.transports.Console)({
+  name: 'console',
+  level: config.server.loggerLevel,
+  colorize: true,
+  handleExceptions: true,
+  humanReadableUnhandledException: true
 });
 
-logger.handleExceptions(new winston.transports.File({
-  filename: path.join(config.logging.folder, 'exceptions.log')
-}));
-
-logger.logException = true;
+var logger = new(winston.Logger)({
+  transports: [consoleTransport],
+});
 
 logger.addExpressApp = function(app) {
-  // Routs to ignore logging.
-  var ignoredRoutes = [
-    "/stylesheets/bootstrapSubmenu.css",
-    "/stylesheets/bootstrap.css",
-    "/javascripts/util.js",
-    "/javascripts/getAudioRecordings.js",
-    "/javascripts/getRecordingLayout.js",
-    "/javascripts/includes/navbar.js",
-    "/stylesheets/bootstrap.css.map"
-  ];
-
   app.use(expressWinston.logger({
-    winstonInstance: logger.transports.info,
-    ignoredRoutes: ignoredRoutes,
+    transports: [consoleTransport],
     meta: false,
     expressFormat: true,
-    handleExceptions: true,
-    humanReadableUnhandledException: true
   }));
-
-  app.use(expressWinston.logger({
-    transports: [new winston.transports.Console({ colorize: true, })],
-    ignoredRoutes: ignoredRoutes,
-    meta: false,
-    expressFormat: true,
-    handleExceptions: true,
-    humanReadableUnhandledException: true
-  }));
-
-  app.use(expressWinston.errorLogger({
-    transports: [
-      new winston.transports.File({
-        filename: path.join(config.logging.folder, 'expressErrors.log')
-      })
-    ]
-  }));
-}
+};
 
 module.exports = logger;

--- a/models/index.js
+++ b/models/index.js
@@ -1,13 +1,11 @@
-var fs = require('fs');
-var path = require('path');
-var Sequelize = require('sequelize');
-var basename = path.basename(module.filename);
-var config = require('../config');
-var log = require('../logging');
+const fs = require('fs');
+const path = require('path');
+const Sequelize = require('sequelize');
+const basename = path.basename(module.filename);
+const config = require('../config');
+const log = require('../logging');
 
-var db = {};
-
-var dbConfig = config.database;
+const dbConfig = config.database;
 
 // Have sequelize send us query execution timings
 dbConfig.benchmark = true;
@@ -17,15 +15,16 @@ dbConfig.logging = function(msg, timeMs) {
   log.debug("%s [%d ms]", msg, timeMs);
 };
 
-var sequelize = new Sequelize(
+const sequelize = new Sequelize(
   dbConfig.database,
   dbConfig.username,
   dbConfig.password,
   dbConfig,
 );
 
-fs
-  .readdirSync(__dirname)
+const db = {};
+
+fs.readdirSync(__dirname)
   .filter(function(file) {
     return (file.indexOf('.') !== 0) &&
       (file !== basename) &&

--- a/models/index.js
+++ b/models/index.js
@@ -2,17 +2,27 @@ var fs = require('fs');
 var path = require('path');
 var Sequelize = require('sequelize');
 var basename = path.basename(module.filename);
-var env = process.env.NODE_ENV || 'development';
 var config = require('../config');
+var log = require('../logging');
 
 var db = {};
 
 var dbConfig = config.database;
+
+// Have sequelize send us query execution timings
+dbConfig.benchmark = true;
+
+// Send logs via winston
+dbConfig.logging = function(msg, timeMs) {
+  log.debug("%s [%d ms]", msg, timeMs);
+};
+
 var sequelize = new Sequelize(
   dbConfig.database,
   dbConfig.username,
   dbConfig.password,
-  dbConfig);
+  dbConfig,
+);
 
 fs
   .readdirSync(__dirname)


### PR DESCRIPTION
Let systemd manage the log output instead of having cacophony-api manage its own log files. This also avoids the confusion of having different log levels spread across different files.

Sequelize's logs are now also sent through winston (at debug). This allows them to be turned off by selecting a log level of info or higher.

A default log level is now set so that database migrations work again.

Closes #53.
