### PR TITLE
Introduce "helper" fixture

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,13 @@
+"""
+pytest fixtures defined in conftest.py are automatically loaded and
+made available for use within tests.
+"""
+
+import pytest
+
+from helper import Helper
+
+
+@pytest.fixture(scope='module')
+def helper():
+    return Helper()

--- a/test/helper.py
+++ b/test/helper.py
@@ -1,10 +1,12 @@
+from datetime import date
+
 from userapi import UserAPI
 from deviceapi import DeviceAPI
-from datetime import date
 from testuser import TestUser
 from testdevice import TestDevice
 from testconfig import TestConfig
 from testexception import TestException
+
 
 class Helper:
 

--- a/test/test_01_user.py
+++ b/test/test_01_user.py
@@ -1,12 +1,5 @@
-import pytest
-from helper import Helper
-
-
 class TestUser:
-
-     def test_can_create_new_user(self):
-        helper = Helper()
-
+    def test_can_create_new_user(self, helper):
         print("If a new user Bob signs up", end='')
         bob = helper.given_new_user(self, 'bob')
 
@@ -19,5 +12,3 @@ class TestUser:
         userdetails = bob.get_user_details(helper.admin_user())
 
         print("Bob's user id is {}".format(userdetails))
-
-    

--- a/test/test_02_thermal_device.py
+++ b/test/test_02_thermal_device.py
@@ -1,10 +1,5 @@
-from helper import Helper
-
-
 class TestThermalDevice:
-    def test_can_upload_cptv(self):
-        helper = Helper()
-
+    def test_can_upload_cptv(self, helper):
         description = "If a new device 'Destroyer' signs up"
         destroyer = helper.given_new_device(self, 'Destroyer', description=description)
 

--- a/test/test_03_group.py
+++ b/test/test_03_group.py
@@ -1,11 +1,8 @@
 import pytest
-from helper import Helper
 
 class TestGroup:
 
-    def test_group_can_be_created_and_users_added_to_it(self):
-        helper = Helper()
-
+    def test_group_can_be_created_and_users_added_to_it(self, helper):
         print("If a new user Clare", end='')
         clare = helper.given_new_user(self, 'clare')
 
@@ -37,9 +34,3 @@ class TestGroup:
 
         # print("  then Daniel should see the recording from 'Terminator'")
         # clare.can_see_recording_from(terminator)
-
-
-
-
-
-

--- a/test/test_04_tagging.py
+++ b/test/test_04_tagging.py
@@ -1,54 +1,61 @@
-import pytest
-from helper import Helper
-
 class TestTagging:
-
-     def test_recording_can_be_retreived_by_tagmode_types(self):
-        helper = Helper()
+    def test_recording_can_be_retreived_by_tagmode_types(self, helper):
         admin = helper.admin_user()
 
         destroyer = helper.given_new_device(self, 'The Destroyer')
 
         possum_human = destroyer.has_recording().is_tagged_as("possum").by(admin)
-        
+
         bird_both = destroyer.has_recording().is_tagged_as("bird").by(admin)
         bird_both.is_tagged_as("bird").byAI(admin)
         stoat_ai = destroyer.has_recording().is_tagged_as("stoat").byAI(admin)
         rat_both_diff = destroyer.has_recording().is_tagged_as("rat").by(admin)
         rat_both_diff.is_tagged_as("hedgehog").byAI(admin)
         no_tag = destroyer.has_recording()
-        
-        allrecordings = [possum_human, bird_both, stoat_ai, rat_both_diff, no_tag]        
+
+        allrecordings = [possum_human, bird_both, stoat_ai, rat_both_diff, no_tag]
 
         admin.can_see_recordings(*allrecordings)
-        
+
         # Tagmode tests
         admin.when_searching_with_tagmode("any").can_see_all_recordings_from_(allrecordings)
 
-        admin.when_searching_with_tagmode("untagged").can_only_see_recordings(no_tag).from_(allrecordings)
-        admin.when_searching_with_tagmode("tagged").can_only_see_recordings(possum_human, bird_both, stoat_ai, rat_both_diff).from_(allrecordings)
+        admin.when_searching_with_tagmode("untagged") \
+             .can_only_see_recordings(no_tag) \
+             .from_(allrecordings)
+        admin.when_searching_with_tagmode("tagged") \
+             .can_only_see_recordings(possum_human, bird_both, stoat_ai, rat_both_diff) \
+             .from_(allrecordings)
 
-        admin.when_searching_with_tagmode("no-human").can_only_see_recordings(no_tag, stoat_ai).from_(allrecordings)
+        admin.when_searching_with_tagmode("no-human") \
+             .can_only_see_recordings(no_tag, stoat_ai).from_(allrecordings)
 
-        admin.when_searching_with_tagmode("human-only").can_only_see_recordings(possum_human).from_(allrecordings)
+        admin.when_searching_with_tagmode("human-only") \
+             .can_only_see_recordings(possum_human).from_(allrecordings)
 
-        admin.when_searching_with_tagmode("automatic-only").can_only_see_recordings(stoat_ai).from_(allrecordings)
+        admin.when_searching_with_tagmode("automatic-only") \
+             .can_only_see_recordings(stoat_ai).from_(allrecordings)
 
-        admin.when_searching_with_tagmode("automatic+human").can_only_see_recordings(rat_both_diff, bird_both).from_(allrecordings)
+        admin.when_searching_with_tagmode("automatic+human") \
+             .can_only_see_recordings(rat_both_diff, bird_both).from_(allrecordings)
 
         # Specified tags tests
         print('Test human only tags found')
-        admin.when_searching_for_tags("possum").can_only_see_recordings(possum_human).from_(allrecordings)
+        admin.when_searching_for_tags("possum") \
+             .can_only_see_recordings(possum_human).from_(allrecordings)
 
         print('Test automatic only tags found')
-        admin.when_searching_for_tags("stoat").can_only_see_recordings(stoat_ai).from_(allrecordings)
+        admin.when_searching_for_tags("stoat") \
+             .can_only_see_recordings(stoat_ai).from_(allrecordings)
 
         print('Test first tag found if different')
-        admin.when_searching_for_tags("hedgehog").can_only_see_recordings(rat_both_diff).from_(allrecordings)
+        admin.when_searching_for_tags("hedgehog") \
+             .can_only_see_recordings(rat_both_diff).from_(allrecordings)
 
         print('Test second tag found if different')
-        admin.when_searching_for_tags("rat").can_only_see_recordings(rat_both_diff).from_(allrecordings)
+        admin.when_searching_for_tags("rat") \
+             .can_only_see_recordings(rat_both_diff).from_(allrecordings)
 
         print('Test several tags found if different')
-        admin.when_searching_for_tags("possum", "bird", "stoat").can_only_see_recordings(possum_human, bird_both, stoat_ai).from_(allrecordings)
-
+        admin.when_searching_for_tags("possum", "bird", "stoat") \
+             .can_only_see_recordings(possum_human, bird_both, stoat_ai).from_(allrecordings)

--- a/test/test_05_audio_device.py
+++ b/test/test_05_audio_device.py
@@ -1,13 +1,7 @@
-from helper import Helper
-
-
 class TestAudioDevice:
-    def test_can_upload_audio(self):
-        helper = Helper()
-
+    def test_can_upload_audio(self, helper):
         description = "If a new device 'Listener' signs up"
-        listener = helper.given_new_device(
-            self, 'Listener', description=description)
+        listener = helper.given_new_device(self, 'Listener', description=description)
 
         print("Then 'Listener' should able to log in")
         helper.login_as_device(listener.devicename)


### PR DESCRIPTION
This makes it easier to make the Helper class available to tests. Using the "module" scope means that the helper is only instantiated once per test module.

Relevant docs: https://docs.pytest.org/en/latest/fixture.html