### PR TITLE
More audio recording tests

### DIFF
--- a/api/V1/requestUtil.js
+++ b/api/V1/requestUtil.js
@@ -13,7 +13,7 @@ var INVALID_HEADER_WHERE =
   '"where" header field was not a valid integer';
 var INVALID_FORM_POST_DATA =
   '"data" field in form was not found or a valid JSON.';
-var INVALDI_FORM_POST_FILE =
+var INVALID_FORM_POST_FILE =
   '"file" field was not found or valid file.';
 var INVALID_TAGS_FIELD =
   '"tags" field was not found or a valid JSON.';
@@ -80,7 +80,7 @@ function getFileAndDataField(request) {
       // TODO do more checks that it is a valid file.
       var file = files.file;
       if (file === null || typeof file !== 'object')
-        return reject({ badRequest: INVALDI_FORM_POST_FILE });
+        return reject({ badRequest: INVALID_FORM_POST_FILE });
 
       return resolve([data, file]);
     });

--- a/api/V1/responseUtil.js
+++ b/api/V1/responseUtil.js
@@ -2,6 +2,7 @@ var log = require('../../logging');
 var jwt = require('jsonwebtoken');
 var config = require('../../config');
 
+var INVALID_ID = 'Invalid id.';
 var INVALID_DATAPOINT_UPLOAD_REQUEST =
   'Request for uploading a datapoint was invalid';
 var INVALID_DATAPOINT_DELETE_REQUEST =
@@ -12,10 +13,6 @@ var INVALID_DATAPOINT_GET_REQUEST =
   'Request for getting datapoints was invalid';
 var INVALID_FILE_REQUEST =
   'Request for file download was invalid';
-var INVALID_ADD_TAGS_REQUEST =
-  'Request to add tags was invalid';
-var INVALID_DELETE_TAGS_REQUEST =
-  'Request to delete tags was invalid';
 var INVALID_GET_TAGS_REQUEST =
   'Request to get tags from datapoint was invalid.';
 var INVALID_VIDEO_PAIR_REQUEST =
@@ -65,6 +62,10 @@ function send(response, data) {
 
 
 //===========INVALID REQUESTS=============
+function invalidDataId(response, message) {
+  badRequest(response, [INVALID_ID, message]);
+}
+
 function invalidDatapointUpload(response, message) {
   badRequest(response, [INVALID_DATAPOINT_UPLOAD_REQUEST, message]);
 }
@@ -216,6 +217,7 @@ function notFromADevice(response) {
 }
 
 exports.send = send;
+exports.invalidDataId = invalidDataId;
 exports.invalidDatapointUpload = invalidDatapointUpload;
 exports.invalidDatapointDelete = invalidDatapointDelete;
 exports.invalidDatapointUpdate = invalidDatapointUpdate;

--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -98,7 +98,7 @@ function getRecordingFile(modelClass, request, response) {
   modelClass
     .getFileData(id, request.user)
     .then((fileData) => {
-      if (fileData === null) {
+      if (fileData === null || fileData.key === null) {
         responseUtil.invalidFileRequest(response, NO_FILE_FOUND);
         throw { badRequest: NO_FILE_FOUND };
       }

--- a/models/util/util.js
+++ b/models/util/util.js
@@ -62,7 +62,7 @@ function findAllWithUser(model, user, queryParams) {
 function processAudio(file) {
   log.debug('Processing audio file.');
   return new Promise(function(resolve, reject) {
-    if (file.type != 'audio/mp3') {
+    if (file.type != 'audio/mp3' && !file.name.endsWith(".mp3")) {
       var convertedAudioPath = file.path + '.mp3';
       ffmpeg(file.path)
         .output(convertedAudioPath)
@@ -89,7 +89,7 @@ function processAudio(file) {
 function processVideo(file) {
   log.debug('Processing video file.');
   return new Promise(function(resolve, reject) {
-    if (file.type != 'video/mp4') {
+    if (file.type != 'video/mp4' && !file.name.endsWith('.mp4')) {
       var convertedVideoPath = file.path + '.mp4';
       ffmpeg(file.path)
         .output(convertedVideoPath)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,10 @@
+import pytest
+
+# Get pytest to generate detail assert failures in our test helper
+# modules.
+pytest.register_assert_rewrite(
+    'test.helper',
+    'test.testdevice',
+    'test.testuser',
+    'test.testrecording',
+)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,7 +5,7 @@ made available for use within tests.
 
 import pytest
 
-from helper import Helper
+from .helper import Helper
 
 
 @pytest.fixture(scope='module')

--- a/test/deviceapi.py
+++ b/test/deviceapi.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 import requests
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
-from apibase import APIBase
+from .apibase import APIBase
 
 
 class DeviceAPI(APIBase):

--- a/test/helper.py
+++ b/test/helper.py
@@ -1,11 +1,11 @@
 from datetime import date
 
-from userapi import UserAPI
-from deviceapi import DeviceAPI
-from testuser import TestUser
-from testdevice import TestDevice
-from testconfig import TestConfig
-from testexception import TestException
+from .userapi import UserAPI
+from .deviceapi import DeviceAPI
+from .testuser import TestUser
+from .testdevice import TestDevice
+from .testconfig import TestConfig
+from .testexception import TestException
 
 
 class Helper:
@@ -43,7 +43,7 @@ class Helper:
         basename = self._make_long_name(testClass, name)
         testname = basename
 
-        for num in range(2,100):
+        for num in range(2, 1000):
             if ('"{}"'.format(testname) not in usednames):
                 return testname
             testname = "{}{}".format(basename, num)

--- a/test/test_05_audio_device.py
+++ b/test/test_05_audio_device.py
@@ -10,4 +10,4 @@ class TestAudioDevice:
         recording = listener.upload_audio_recording()
 
         print("And the audio file should be visible to super users")
-        helper.admin_user().can_see_audio_recording(recording.recordingId)
+        helper.admin_user().can_see_audio_recording(recording)

--- a/test/test_06_user_audio.py
+++ b/test/test_06_user_audio.py
@@ -20,3 +20,27 @@ class TestUserAudio:
         print("\nA user should be able to download the audio recording")
         user = helper.admin_user()
         user.can_download_correct_audio_recording(recording)
+
+    def test_can_query_audio_recordings(self, helper):
+        print("If a new user clare", end='')
+        clare = helper.given_new_user(self, 'clare')
+
+        print("   has a new group called 'area51'", end='')
+        group_name = helper.make_unique_group_name(self, 'area51')
+        clare.create_group(group_name)
+        print("({})".format(group_name))
+
+        description = "  and there is a new device called 'Bob' in this group"
+        device = helper.given_new_device(self, 'Bob', group_name, description=description)
+
+        print("There should be no recordings initially")
+        clare.cannot_see_any_audio_recordings()
+
+        print("When recordings are uploaded")
+        recordings = []
+        for _ in range(5):
+            recordings.append(device.has_audio_recording())
+            print()
+
+        print("Clare should be able to see exactly those the recordings")
+        clare.can_see_audio_recordings(recordings)

--- a/test/test_06_user_audio.py
+++ b/test/test_06_user_audio.py
@@ -12,3 +12,11 @@ class TestUserAudio:
 
         print("they can no longer see it.")
         user.cannot_see_audio_recording(recording)
+
+    def test_can_download_audio(self, helper):
+        phone = helper.given_new_device(self, 'phone')
+        recording = phone.has_audio_recording()
+
+        print("\nA user should be able to download the audio recording")
+        user = helper.admin_user()
+        user.can_download_correct_audio_recording(recording)

--- a/test/test_06_user_audio.py
+++ b/test/test_06_user_audio.py
@@ -5,7 +5,7 @@ class TestUserAudio:
 
         print("\nA user should be able to see the audio recording")
         user = helper.admin_user()
-        user.can_see_audio_recording(recording.recordingId)
+        user.can_see_audio_recording(recording)
 
         print("And when they delete it ... ", end='')
         user.delete_audio_recording(recording)

--- a/test/test_06_user_audio.py
+++ b/test/test_06_user_audio.py
@@ -1,0 +1,14 @@
+class TestUserAudio:
+    def test_can_delete_audio(self, helper):
+        phone = helper.given_new_device(self, 'phone')
+        recording = phone.has_audio_recording()
+
+        print("\nA user should be able to see the audio recording")
+        user = helper.admin_user()
+        user.can_see_audio_recording(recording.recordingId)
+
+        print("And when they delete it ... ", end='')
+        user.delete_audio_recording(recording)
+
+        print("they can no longer see it.")
+        user.cannot_see_audio_recording(recording)

--- a/test/testconfig.py
+++ b/test/testconfig.py
@@ -1,27 +1,28 @@
 import json
 from pathlib import Path
-from testexception import TestException
 
-class TestConfig: 
 
-    def __init__(self, 
-                api_server = 'http://127.0.0.1:1080',
-                admin_username = 'admin_test',
-                admin_password = 'admin_test', 
-                default_group = 'test-group'):
+class TestConfig:
+    def __init__(self,
+                 api_server='http://127.0.0.1:1080',
+                 admin_username='admin_test',
+                 admin_password='admin_test',
+                 default_group='test-group'):
         self.api_server = api_server
         self.admin_username = admin_username
         self.admin_password = admin_password
         self.default_group = default_group
 
-    def load_config(self): 
+    def load_config(self):
         config_file = 'testconfig.json'
 
         if not Path(config_file).is_file():
-            print("No config file '{}'.  Running with default config.".format(config_file))
+            print("No config file '{}'.  Running with default config.".format(
+                config_file))
             return self
-        
+
         with open(config_file) as json_data_file:
-            print("Attempting to load config from file '{}'...".format(config_file))
+            print("Attempting to load config from file '{}'...".format(
+                config_file))
             data = json.load(json_data_file)
-            return TestConfig(**data)                  
+            return TestConfig(**data)

--- a/test/testdevice.py
+++ b/test/testdevice.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 import json
 
-from testrecording import TestRecording
+from .testrecording import TestRecording
 
 
 class TestDevice:

--- a/test/testdevice.py
+++ b/test/testdevice.py
@@ -15,6 +15,11 @@ class TestDevice:
             self.devicename))
         return self.upload_recording()
 
+    def has_audio_recording(self):
+        self._print_description("    and '{}' has an audio recording ".format(
+            self.devicename))
+        return self.upload_audio_recording()
+
     def upload_recording(self):
         props = json.dumps({
             "type": "thermalRaw",

--- a/test/testdevice.py
+++ b/test/testdevice.py
@@ -26,18 +26,18 @@ class TestDevice:
             "recordingDateTime": self._make_timestamp(),
             "duration": 10,
         })
-        recording_id = self._deviceapi.upload_recording(
-            'files/small.cptv', props)
-        return TestRecording(recording_id)
+        filename = 'files/small.cptv'
+        recording_id = self._deviceapi.upload_recording(filename, props)
+        return TestRecording(recording_id, slurp(filename))
 
     def upload_audio_recording(self):
         props = json.dumps({
             "recordingDateTime": self._make_timestamp(),
             "duration": 1,
         })
-        recording_id = self._deviceapi.upload_audio_recording(
-            'files/small.mp3', props)
-        return TestRecording(recording_id)
+        filename = 'files/small.mp3'
+        recording_id = self._deviceapi.upload_audio_recording(filename, props)
+        return TestRecording(recording_id, slurp(filename))
 
     def _make_timestamp(self):
         # recordings need to be recorded at different second times else the search code doesn't work
@@ -48,3 +48,8 @@ class TestDevice:
 
     def _print_description(self, description):
         print(description, end='')
+
+
+def slurp(filename):
+    with open(filename, 'rb') as f:
+        return f.read()

--- a/test/testrecording.py
+++ b/test/testrecording.py
@@ -1,11 +1,11 @@
 class TestRecording:
-
-    def __init__(self, recordingId):
+    def __init__(self, recordingId, content):
         self.recordingId = recordingId
+        self.content = content
 
     def is_tagged_as(self, animal):
         return TestTagPromise(self, animal)
-        
+
 
 class TestTagPromise():
     def __init__(self, testrecording, animal):

--- a/test/testrecording.py
+++ b/test/testrecording.py
@@ -3,6 +3,9 @@ class TestRecording:
         self.recordingId = recordingId
         self.content = content
 
+    def __repr__(self):
+        return "<TestRecording: {}>".format(self.recordingId)
+
     def is_tagged_as(self, animal):
         return TestTagPromise(self, animal)
 

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -2,7 +2,7 @@ import io
 
 import pytest
 
-from testexception import TestException
+from .testexception import TestException
 
 
 class TestUser:

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -72,8 +72,8 @@ class TestUser:
         assert lastDevice == testdevice.devicename, \
             "Latest recording is from device '{}', not from '{}'".format(lastDevice, testdevice.devicename)
 
-    def can_see_audio_recording(self, recording_id):
-        self._userapi.get_audio(recording_id)
+    def can_see_audio_recording(self, recording):
+        self._userapi.get_audio(recording.recordingId)
 
     def cannot_see_audio_recording(self, recording):
         with pytest.raises(IOError, match=r'.*No file found with given datapoint.'):

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -102,6 +102,15 @@ class TestUser:
         with pytest.raises(IOError, match=r'.*No file found with given datapoint.'):
             self._userapi.get_audio(recording.recordingId)
 
+    def cannot_see_any_audio_recordings(self):
+        rows = self._userapi.query_audio()
+        assert not rows
+
+    def can_see_audio_recordings(self, recordings):
+        expected_ids = {rec.recordingId for rec in recordings}
+        actual_ids = {row['id'] for row in self._userapi.query_audio()}
+        assert actual_ids == expected_ids
+
     def delete_audio_recording(self, recording):
         self._userapi.delete_audio(recording.recordingId)
 

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -1,3 +1,5 @@
+import pytest
+
 from testexception import TestException
 
 
@@ -61,9 +63,6 @@ class TestUser:
                 return True
         return False
 
-    def can_see_audio_recording(self, recording_id):
-        self._userapi.get_audio(recording_id)
-
     def can_see_recording_from(self, testdevice):
         recordings = self._userapi.query(limit=1)
         assert recordings, \
@@ -72,6 +71,16 @@ class TestUser:
         lastDevice = recordings[0]['Device']['devicename']
         assert lastDevice == testdevice.devicename, \
             "Latest recording is from device '{}', not from '{}'".format(lastDevice, testdevice.devicename)
+
+    def can_see_audio_recording(self, recording_id):
+        self._userapi.get_audio(recording_id)
+
+    def cannot_see_audio_recording(self, recording):
+        with pytest.raises(IOError, match=r'.*No file found with given datapoint.'):
+            self._userapi.get_audio(recording.recordingId)
+
+    def delete_audio_recording(self, recording):
+        self._userapi.delete_audio(recording.recordingId)
 
     def cannot_see_any_recordings(self):
         recordings = self._userapi.query(limit=10)

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 
 from testexception import TestException
@@ -72,16 +74,6 @@ class TestUser:
         assert lastDevice == testdevice.devicename, \
             "Latest recording is from device '{}', not from '{}'".format(lastDevice, testdevice.devicename)
 
-    def can_see_audio_recording(self, recording):
-        self._userapi.get_audio(recording.recordingId)
-
-    def cannot_see_audio_recording(self, recording):
-        with pytest.raises(IOError, match=r'.*No file found with given datapoint.'):
-            self._userapi.get_audio(recording.recordingId)
-
-    def delete_audio_recording(self, recording):
-        self._userapi.delete_audio(recording.recordingId)
-
     def cannot_see_any_recordings(self):
         recordings = self._userapi.query(limit=10)
         if recordings:
@@ -102,6 +94,22 @@ class TestUser:
 
     def tag_recording(self, recordingId, tagDictionary):
         self._userapi.tag_recording(recordingId, tagDictionary)
+
+    def can_see_audio_recording(self, recording):
+        self._userapi.get_audio(recording.recordingId)
+
+    def cannot_see_audio_recording(self, recording):
+        with pytest.raises(IOError, match=r'.*No file found with given datapoint.'):
+            self._userapi.get_audio(recording.recordingId)
+
+    def delete_audio_recording(self, recording):
+        self._userapi.delete_audio(recording.recordingId)
+
+    def can_download_correct_audio_recording(self, recording):
+        content = io.BytesIO()
+        for chunk in self._userapi.download_audio(recording.recordingId):
+            content.write(chunk)
+        assert content.getvalue() == recording.content
 
 
 class RecordingQueryPromise:

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -77,6 +77,11 @@ class UserAPI(APIBase):
         r = requests.get(url, headers=self._auth_header)
         return self._check_response(r)
 
+    def delete_audio(self, recording_id):
+        url = urljoin(self._baseurl, '/api/v1/audiorecordings/{}'.format(recording_id))
+        r = requests.delete(url, headers=self._auth_header)
+        return self._check_response(r)
+
     def download_cptv(self, id):
         return self._download_recording(id, 'downloadRawJWT')
 

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -1,8 +1,8 @@
-from apibase import APIBase
-
 import json
 import requests
 from urllib.parse import urljoin
+
+from .apibase import APIBase
 
 
 class UserAPI(APIBase):

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -42,6 +42,19 @@ class UserAPI(APIBase):
         else:
             r.raise_for_status()
 
+
+    def download_cptv(self, id):
+        return self._download_recording(id, 'downloadRawJWT')
+
+    def download_mp4(self, id):
+        return self._download_recording(id, 'downloadFileJWT')
+
+    def _download_recording(self, id, jwt_key):
+        url = urljoin(self._baseurl, '/api/v1/recordings/{}'.format(id))
+        r = requests.get(url, headers=self._auth_header)
+        d = self._check_response(r)
+        return self._download_signed(d[jwt_key])
+
     def query_audio(self, startDate=None, endDate=None, min_secs=0, limit=100, offset=0):
         url = urljoin(self._baseurl, '/api/v1/audiorecordings')
 
@@ -82,17 +95,11 @@ class UserAPI(APIBase):
         r = requests.delete(url, headers=self._auth_header)
         return self._check_response(r)
 
-    def download_cptv(self, id):
-        return self._download_recording(id, 'downloadRawJWT')
-
-    def download_mp4(self, id):
-        return self._download_recording(id, 'downloadFileJWT')
-
-    def _download_recording(self, id, jwt_key):
-        url = urljoin(self._baseurl, '/api/v1/recordings/{}'.format(id))
+    def download_audio(self, recording_id):
+        url = urljoin(self._baseurl, '/api/v1/audiorecordings/{}'.format(recording_id))
         r = requests.get(url, headers=self._auth_header)
         d = self._check_response(r)
-        return self._download_signed(d[jwt_key])
+        return self._download_signed(d['jwt'])
 
     def _download_signed(self, token):
         r = requests.get(


### PR DESCRIPTION
This implements tests for the following URLs:
* DELETE api/V1/audiorecordings/:id
* GET api/V1/audiorecordings/:id (and then actually validating downloads)
* GET api/V1/audiorecordings/

Additionally:
* The missing `responseUtil.invalidDataId` function was added
* GET api/V1/audiorecordings/:id was changed to return a 400 if file processing hadn't completed yet
* Processing is skipped based on the filename as well as the mime type 
* Various typos in the JavaScript code were fixed
* pytest will now produce detailed assertion reports in our test helper modules.