### PR TITLE
Log validation error details

### DIFF
--- a/api/customErrors.js
+++ b/api/customErrors.js
@@ -2,11 +2,12 @@ const log    = require('../logging');
 const format = require('util').format;
 
 function errorHandler(err, request, response, next) { // eslint-disable-line
-  log.error(err);
   if (err instanceof CustomError) {
+    log.warn(err.toString());
     response.status(err.statusCode).json(err.toJson());
     return;
   }
+  log.error(err);
   response.status(500).json({
     message: "server error",
     errorType: "server"
@@ -22,22 +23,28 @@ function ValidationError(errors) {
   this.name = "validation";
   this.statusCode = 422;
   this.errors = errors;
-  this.toJson = () => {
+  this.flatten = () => {
     const mappedErrors = this.errors.mapped();
-    var errorList = [];
-    for (var key in mappedErrors) {
-      if (typeof mappedErrors[key].msg == "string") {
-        var msg = format(
-          "Parameter '%s' failed because: %s.\n",
-          mappedErrors[key].param,
-          mappedErrors[key].msg,
-        );
-        errorList.push(msg);
+    var errors = [];
+    for (let name in mappedErrors) {
+      let error = mappedErrors[name];
+      if (typeof error.msg == "string") {
+        errors.push(format(
+          "%s: %s",
+          name,
+          error.msg,
+        ));
       }
     }
+    return errors.join('; ');
+  };
+  this.toString = () => {
+    return format("%s error[%d]: %s", this.name, this.statusCode, this.flatten());
+  };
+  this.toJson = () => {
     return {
-      message: errorList.join('. '),
       errorType: this.name,
+      message: this.flatten(),
       errors: this.errors.mapped(),
     };
   };
@@ -45,13 +52,16 @@ function ValidationError(errors) {
 ValidationError.prototype = new CustomError();
 ValidationError.prototype.constructor = ClientError;
 
-function ClientError(message, httpStatusCode) {
-  if (httpStatusCode == undefined) {
-    httpStatusCode = 400;
+function ClientError(message, statusCode) {
+  if (statusCode == undefined) {
+    statusCode = 400;
   }
-  this.message = message;
   this.name = "client";
-  this.statusCode = httpStatusCode;
+  this.message = message;
+  this.statusCode = statusCode;
+  this.toString = () => {
+    return format("%s error[%d]: %s", this.name, statusCode, message);
+  };
   this.toJson = () => {
     return {
       message: message,


### PR DESCRIPTION
When parameter validation fails, instead of logging a traceback with
no useful information, log the validation issues instead.

To support this, CustomErrors are now implement toString() as well as
toJson().