### PR TITLE
Docker improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ apidoc/*
 testconfig.json
 .pytest_cache
 __pycache__
-docker-container-pid

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ RUN echo "Pacific/Auckland" > /etc/timezone
 RUN ln -sf /usr/share/zoneinfo/Pacific/Auckland /etc/localtime
 
 RUN apt-get -y install curl wget sudo make build-essential g++
+
 RUN apt-get -y install postgis postgresql-server-dev-9.5
+RUN echo "listen_addresses = '*'" >> /etc/postgresql/9.5/main/postgresql.conf
+RUN echo "host all all 0.0.0.0/0 md5" >> /etc/postgresql/9.5/main/pg_hba.conf
+RUN echo "host all all ::/0 md5" >> /etc/postgresql/9.5/main/pg_hba.conf
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,16 @@ RUN chmod +x mc
 
 COPY docker-entrypoint.sh /
 
+# API
 EXPOSE 1080
-EXPOSE 9001
+
+# API - fileProcessing
 EXPOSE 2008
+
+# Minio
+EXPOSE 9001
+
+# PostgreSQL
+EXPOSE 5432
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -e
 
-echo "listen_addresses = '*'" >> /etc/postgresql/9.5/main/postgresql.conf
-
-service postgresql restart
+service postgresql start
 
 sudo -i -u postgres psql -c "CREATE USER test with password 'test'"
 sudo -i -u postgres psql -c "CREATE DATABASE cacophonytest WITH OWNER test;"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 set -e
 
+export MINIO_ACCESS_KEY=minio
+export MINIO_SECRET_KEY=miniostorage
+./minio server --address :9001 .data &> minio.log &
+
 service postgresql start
 
 sudo -i -u postgres psql -c "CREATE USER test with password 'test'"
 sudo -i -u postgres psql -c "CREATE DATABASE cacophonytest WITH OWNER test;"
 sudo -i -u postgres psql cacophonytest -c "CREATE EXTENSION postgis"
+
+./mc config host add myminio http://127.0.0.1:9001 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+./mc mb myminio/cacophony
 
 echo "[hit enter key to exit] or run 'docker stop <container>'"
 

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -2,16 +2,9 @@
 
 if [ -f docker-container-pid ]; then
     pid="$(cat docker-container-pid)"
-
     echo "Stopping container <$pid>"
-    sudo docker stop $pid &> /dev/null
-
-    sleep 5
-    
-    echo "Removing container <$pid>"
-    sudo docker rm $pid &> /dev/null
-
-    rm docker-container-pid
+    sudo docker rm --force $pid &> /dev/null
+    rm -f docker-container-pid
 fi
 
 sudo docker build . -t cacophony-api

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,31 +1,30 @@
 #/bin/bash
 
-if [ -f docker-container-pid ]; then
-    pid="$(cat docker-container-pid)"
-    echo "Stopping container <$pid>"
-    sudo docker rm --force $pid &> /dev/null
-    rm -f docker-container-pid
-fi
+image_name=cacophony-api
+container_name="cacophony-api-test"
 
-sudo docker build . -t cacophony-api
+echo "Stopping $cacophony-api-test container"
+sudo docker rm --force $container_name &> /dev/null
+
+sudo docker build . -t $image_name
 
 # Publish PostgreSQL on a different port externally (5400) to avoid
 # collisions with an PostgreSQL instance on the host.
 sudo docker run -td --rm \
-     --name cacophony-api-test \
+     --name $container_name \
      -p 1080:1080 \
      -p 9001:9001 \
      -p 5400:5432 \
-     cacophony-api | tee > docker-container-pid
+     $image_name
 
-sudo docker cp . cacophony-api-test:/
-sudo docker exec cacophony-api-test bash -c "$@ rm -r /node_modules"
-sudo docker exec cacophony-api-test bash -c "$@ echo 'npm install...'        && npm install"
-sudo docker exec cacophony-api-test bash -c "$@ echo 'migrating database...' && node_modules/sequelize-cli/bin/sequelize db:migrate --config config/app_test_default.js"
-sudo docker exec cacophony-api-test bash -c "sudo -i -u postgres psql cacophonytest -f /test/db-seed.sql"
-sudo docker exec cacophony-api-test bash -c "$@ MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=miniostorage ./minio server --address :9001 .data &> miniolog &"
-sudo docker exec cacophony-api-test bash -c "$@ sleep 10" # Allowing minio to initialize
-sudo docker exec cacophony-api-test bash -c "./mc config host add myminio http://127.0.0.1:9001 minio miniostorage"
-sudo docker exec cacophony-api-test bash -c "./mc mb myminio/cacophony"
+sudo docker cp . $container_name:/
+sudo docker exec $container_name bash -c "$@ rm -r /node_modules"
+sudo docker exec $container_name bash -c "$@ echo 'npm install...'        && npm install"
+sudo docker exec $container_name bash -c "$@ echo 'migrating database...' && node_modules/sequelize-cli/bin/sequelize db:migrate --config config/app_test_default.js"
+sudo docker exec $container_name bash -c "sudo -i -u postgres psql cacophonytest -f /test/db-seed.sql"
+sudo docker exec $container_name bash -c "$@ MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=miniostorage ./minio server --address :9001 .data &> miniolog &"
+sudo docker exec $container_name bash -c "$@ sleep 10" # Allowing minio to initialize
+sudo docker exec $container_name bash -c "./mc config host add myminio http://127.0.0.1:9001 minio miniostorage"
+sudo docker exec $container_name bash -c "./mc mb myminio/cacophony"
 
-sudo docker exec cacophony-api-test bash -c "$@ node /Server.js --config=config/app_test_default.js${BG:+ &> /dev/null &}"
+sudo docker exec $container_name bash -c "$@ node /Server.js --config=config/app_test_default.js${BG:+ &> /dev/null &}"

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -3,7 +3,7 @@
 image_name=cacophony-api
 container_name="cacophony-api-test"
 
-echo "Stopping $cacophony-api-test container"
+echo "Stopping $container_name container (if running)"
 sudo docker rm --force $container_name &> /dev/null
 
 sudo docker build . -t $image_name
@@ -22,9 +22,4 @@ sudo docker exec $container_name bash -c "$@ rm -r /node_modules"
 sudo docker exec $container_name bash -c "$@ echo 'npm install...'        && npm install"
 sudo docker exec $container_name bash -c "$@ echo 'migrating database...' && node_modules/sequelize-cli/bin/sequelize db:migrate --config config/app_test_default.js"
 sudo docker exec $container_name bash -c "sudo -i -u postgres psql cacophonytest -f /test/db-seed.sql"
-sudo docker exec $container_name bash -c "$@ MINIO_ACCESS_KEY=minio MINIO_SECRET_KEY=miniostorage ./minio server --address :9001 .data &> miniolog &"
-sudo docker exec $container_name bash -c "$@ sleep 10" # Allowing minio to initialize
-sudo docker exec $container_name bash -c "./mc config host add myminio http://127.0.0.1:9001 minio miniostorage"
-sudo docker exec $container_name bash -c "./mc mb myminio/cacophony"
-
 sudo docker exec $container_name bash -c "$@ node /Server.js --config=config/app_test_default.js${BG:+ &> /dev/null &}"

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -8,7 +8,15 @@ if [ -f docker-container-pid ]; then
 fi
 
 sudo docker build . -t cacophony-api
-sudo docker run -td --rm --name cacophony-api-test -p 1080:1080 -p 9001:9001 cacophony-api | tee > docker-container-pid
+
+# Publish PostgreSQL on a different port externally (5400) to avoid
+# collisions with an PostgreSQL instance on the host.
+sudo docker run -td --rm \
+     --name cacophony-api-test \
+     -p 1080:1080 \
+     -p 9001:9001 \
+     -p 5400:5432 \
+     cacophony-api | tee > docker-container-pid
 
 sudo docker cp . cacophony-api-test:/
 sudo docker exec cacophony-api-test bash -c "$@ rm -r /node_modules"


### PR DESCRIPTION
* Configure PostgreSQL in docker image instead of in the docker entry
  point. There no reason to delay this until container startup.
* Simplify stopping of the container
* Expose PostgreSQL server port from container. This is useful for
  development and confirming DB contents from the
  outside. PostgreSQL's port is exposed at 5400 to avoid collisions
  with a PostgreSQL server on the host.
* Avoid the need for the container pid file Given that a static container name is used, the pid file is unnecessary.
* Move minio startup to docker-entrypoint. This makes more sense given
  that setting up Minio doesn't depend on the cacophony-api
  code. This also speeds things up somewhat.