### PR TITLE
Fail on missing deps

### DIFF
--- a/Server.js
+++ b/Server.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var bodyParser = require('body-parser');
 var passport = require('passport');
+var process = require('process');
 var http = require('http');
 
 var configPath = './config/app.js';
@@ -61,6 +62,7 @@ models.sequelize
   .then(() => openHttpServer(app))
   .catch(function(error) {
     log.error(error);
+    process.exit(2);
   });
 
 function openHttpServer(app) {

--- a/_release/cacophony-api.service
+++ b/_release/cacophony-api.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Cacophony Project API server
+After=network.target
+
+[Service]
+WorkingDirectory=/srv/cacophony/api
+ExecStart=/usr/local/bin/node Server.js
+Restart=on-failure
+RestartSec=5s
+User=fullnoise
+Group=fullnoise
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Exit if PostgreSQL or Minio connection fails

Previously the server would be running but in a non-functional
way. Now systemd can keep restarting the service unil the missing
database service is back up.

Include systemd service file in version control.