### PR TITLE
Add rawMimeType column to Recordings

### DIFF
--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -196,6 +196,7 @@ function multipartDownload(recordTypeName, buildRecord){
   return (request, response) => {
     var key = uuidv4();
     var data;
+    var filename;
     var upload;
 
     // Note regarding multiparty: there are no guarantees about the
@@ -224,6 +225,7 @@ function multipartDownload(recordTypeName, buildRecord){
         part.resume();
         return;
       }
+      filename = part.filename;
 
       upload = modelsUtil.openS3().upload({
         Bucket: config.s3.bucket,
@@ -264,6 +266,8 @@ function multipartDownload(recordTypeName, buildRecord){
           return;
         }
         log.info("finished streaming upload to object store. key:", key);
+
+        data.filename = filename;
 
         // Store a record for the upload.
         dbRecord = buildRecord(request, data, key);

--- a/migrations/20180627034101-add-rawmimetype.js
+++ b/migrations/20180627034101-add-rawmimetype.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  up: async function (queryInterface, Sequelize) {
+    await queryInterface.addColumn('Recordings', 'rawMimeType', Sequelize.STRING);
+    await queryInterface.sequelize.query(`
+        UPDATE "Recordings"
+        SET "rawMimeType" = 'application/x-cptv'
+        WHERE type = 'thermalRaw'
+    `);
+  },
+
+  down: async function (queryInterface) {
+    await queryInterface.removeColumn('Recordings', 'rawMimeType');
+  }
+};

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -1,6 +1,9 @@
+var mime = require('mime');
+var moment = require('moment-timezone');
+
 var util = require('./util/util');
 var validation = require('./util/validation');
-var moment = require('moment-timezone');
+
 
 module.exports = function(sequelize, DataTypes) {
   var name = 'Recording';
@@ -25,6 +28,7 @@ module.exports = function(sequelize, DataTypes) {
     // Raw file data.
     rawFileKey: DataTypes.STRING,
     rawFileSize: DataTypes.INTEGER,
+    rawMimeType: DataTypes.STRING,
 
     // Processing fields. Fields set by and for the processing.
     fileKey: DataTypes.STRING,
@@ -204,12 +208,27 @@ module.exports = function(sequelize, DataTypes) {
     ]};
   };
 
-  var getRawFileName = function() {
-    var ext = '';
-    if (this.type == 'thermalRaw') {
-      ext = '.cptv';
-    }
+  const getRawFileName = function() {
+    const ext = this.getRawFileExt();
     return moment.tz('Pacific/Auckland').format('YYYYMMDD-HHmmss') + ext;
+  };
+
+  const getRawFileExt = function() {
+    if (this.rawMimeType == 'application/x-cptv') {
+      return ".cptv";
+    }
+    const ext = mime.getExtension(this.rawMimeType);
+    if (ext) {
+      return '.' + ext;
+    }
+    switch (this.type) {
+    case 'thermalRaw':
+      return '.cptv';
+    case 'audio':
+      return '.mpga';
+    default:
+      return "";
+    }
   };
 
   var options = {
@@ -229,6 +248,7 @@ module.exports = function(sequelize, DataTypes) {
       canGetRaw: canGetRaw,
       getFileName: getFileName,
       getRawFileName: getRawFileName,
+      getRawFileExt: getRawFileExt,
       getUserPermissions: getUserPermissions,
     },
   };
@@ -291,6 +311,7 @@ function getFileName() {
 var userGetAttributes = [
   'id',
   'rawFileSize',
+  'rawMimeType',
   'fileSize',
   'fileMimeType',
   'processingState',

--- a/test/testdevice.py
+++ b/test/testdevice.py
@@ -37,6 +37,10 @@ class TestDevice:
         }
         filename = 'files/small.cptv'
         recording_id = self._deviceapi.upload_recording(filename, props)
+
+        # Expect to see this in data returned by the API server.
+        props['rawMimeType'] = 'application/x-cptv'
+
         return TestRecording(recording_id, props, slurp(filename))
 
     def upload_audio_recording(self):

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -95,11 +95,13 @@ class TestUser:
         del recv_props['Tags']
         del recv_props['GroupId']
         del recv_props['location']
-        del recv_props['fileKey']
         del recv_props['rawFileKey']
         del recv_props['rawFileSize']
-        del recv_props['fileMimeType']
+        if 'rawMimeType' not in props:
+            del recv_props['rawMimeType']
+        del recv_props['fileKey']
         del recv_props['fileSize']
+        del recv_props['fileMimeType']
 
         assert recv_props.pop('id') == recording.recordingId
         assert recv_props.pop('processingState') == 'toMp4'


### PR DESCRIPTION
In order appropriately handle raw content, it's useful to know the
MIME type. Handling for both CPTV and MP3 files has been taken care of.

This is part of the work of for merge AudioRecordings and Recordings.