### PR TITLE
Return mime types from fileProcessing API

### DIFF
--- a/models/Recording.js
+++ b/models/Recording.js
@@ -363,12 +363,14 @@ var processingStates = {
 
 var processingAttributes = [
   'id',
-  'rawFileKey',
-  'fileKey',
-  'processingMeta',
-  'processingState',
-  'jobKey',
   'type',
+  'jobKey',
+  'rawFileKey',
+  'rawMimeType',
+  'fileKey',
+  'fileMimeType',
+  'processingState',
+  'processingMeta',
 ];
 
 const validTagModes = Object.freeze([


### PR DESCRIPTION
This helps cacophony-processing to know what to do with a recording.