### PR TITLE
Store audio recordings in the Recordings table

### DIFF
--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -1,14 +1,29 @@
+const { query, check }  = require('express-validator/check');
+const moment = require('moment');
+const { format } = require('util');
+
 const middleware = require('../middleware');
 const models = require('../../models');
-const util = require('./util');
+const recordingUtil = require('./recordingUtil');
+const responseUtil = require('./responseUtil');
+
 
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/audiorecordings';
+
+
+  // Massage fields sent to the legacy AudioRecordings API so that
+  // they work in the Recordings schema.
+  const mungeAudioData = function(data) {
+    data.type = 'audio';
+    return data;
+  };
 
   /**
   * @api {post} /api/v1/audiorecordings/ Add a new audio recording
   * @apiName PostAudioRecording
   * @apiGroup AudioRecordings
+  * @apiDeprecated use now (#Recordings:PostRecording)
   * @apiDescription This call is used to upload new audio recording. It takes a
   * `data` field which contains JSON object string that may contain any of the
   * following fields:
@@ -37,20 +52,18 @@ module.exports = function(app, baseUrl) {
     [
       middleware.authenticateDevice,
     ],
-    middleware.requestWrapper(async (req, res) => {
-      return util.addRecordingFromPost(models.AudioRecording, req, res);
-    })
+    middleware.requestWrapper(
+      recordingUtil.makeUploadHandler(mungeAudioData)
+    )
   );
-
 
   /**
   * @api {put} /api/v1/audiorecordings/:id Update the metadata for an existing audio recording
   * @apiName UpdateAudioRecording
   * @apiGroup AudioRecordings
+  * @apiDeprecated use now (#Recordings:UpdateRecording)
   * @apiDescription This call is used to update the metadata for a previously
   * uploaded audio recording. It takes a `data` field which may contain any of the following fields:
-  * - recordingDateTime
-  * - recordingTime
   * - location
   * - additionalMetadata
   *
@@ -65,9 +78,18 @@ module.exports = function(app, baseUrl) {
     apiUrl + "/:id",
     [
       middleware.authenticateUser,
+      check('id').isInt(),
+      middleware.parseJSON('data'),
     ],
-    middleware.requestWrapper(async (req, res) => {
-      return util.updateDataFromPut(models.AudioRecording, req, res);
+    middleware.requestWrapper(async (request, response) => {
+      var updated = await models.Recording.updateOne(
+        request.user, request.params.id, request.body.data);
+
+      if (updated) {
+        responseUtil.validDatapointUpdate(response);
+      } else {
+        responseUtil.invalidDatapointUpdate(response, 'Failed to update recordings.');
+      }
     })
   );
 
@@ -75,6 +97,7 @@ module.exports = function(app, baseUrl) {
   * @api {delete} /api/v1/audiorecordings/:id Delete an existing audio recording
   * @apiName DeleteAudioRecording
   * @apiGroup AudioRecordings
+  * @apiDeprecated use now (#Recordings:DeleteRecording)
   *
   * @apiUse V1UserAuthorizationHeader
   *
@@ -86,8 +109,8 @@ module.exports = function(app, baseUrl) {
     [
       middleware.authenticateUser,
     ],
-    middleware.requestWrapper(async (req, res) => {
-      return util.deleteDataPoint(models.AudioRecording, req, res);
+    middleware.requestWrapper(async (request, response) => {
+      await recordingUtil.delete_(request, response);
     })
   );
 
@@ -95,6 +118,7 @@ module.exports = function(app, baseUrl) {
   * @api {get} /api/v1/audiorecordings/ Query available audio recordings
   * @apiName GetAudioRecordings
   * @apiGroup AudioRecordings
+  * @apiDeprecated use now (#Recordings:QueryRecordings)
   *
   * @apiUse V1UserAuthorizationHeader
   *
@@ -114,16 +138,60 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateUser,
+      middleware.parseJSON('where').optional(),
+      check('offset').isInt(),
+      check('limit').isInt(),
     ],
-    middleware.requestWrapper(async (req, res) => {
-      return util.getRecordingsFromModel(models.AudioRecording, req, res);
+    middleware.requestWrapper(async (request, response) => {
+      const qresult = await recordingUtil.query(request, "audio");
+      var result = {
+        rows: [],
+        limit: request.query.limit,
+        offset: request.query.offset,
+        count: qresult.count,
+      };
+
+      // Just save the front end fields for each model.
+      for (let row of qresult.rows) {
+        result.rows.push(getFrontendFields(row));
+      }
+      responseUtil.validDatapointGet(response, result);
     })
   );
+
+  const getFrontendFields = function(rec) {
+    const out = {
+      id: rec.id,
+      recordingDateTime: rec.recordingDateTime,
+      relativeToDawn: rec.relativeToDawn,
+      relativeToDusk: rec.relativeToDusk,
+      recordingTime: moment.parseZone(format("%o", rec.recordingDateTime)).format("HH:mm:ss"),
+      duration: rec.duration,
+      location: rec.location,
+      fileKey: rec.fileKey,
+      batteryCharging: rec.batteryCharging,
+      batteryLevel: rec.batteryLevel,
+      airplaneModeOn: rec.airplaneModeOn,
+      version: rec.version,
+      deviceId: rec.Device.id,
+      groupId: rec.Group.id,
+      group: rec.Group.groupname,
+      additionalMetadata: rec.additionalMetadata,
+    };
+    if (rec.relativeToDawn) {
+      out.relativeToDawn = rec.relativeToDawn;
+    }
+    if (rec.relativeToDusk) {
+      out.relativeToDusk = rec.relativeToDusk;
+    }
+    return out;
+  };
 
   /**
   * @api {get} /api/v1/audiorecordings/:id Obtain token for retrieving audio recording
   * @apiName GetAudioRecording
   * @apiGroup AudioRecordings
+  * @apiDeprecated use now (#Recordings:GetRecording)
   * @apiDescription This call returns a new JSON Web Token (JWT) which
   * can be used to retrieve a specific audio recording. This is should
   * be used with the [/api/v1/signedUrl API](#api-SignedUrl-GetFile).
@@ -139,9 +207,17 @@ module.exports = function(app, baseUrl) {
     apiUrl + "/:id",
     [
       middleware.authenticateUser,
+      check('id').isInt(),
     ],
-    middleware.requestWrapper(async (req, res) => {
-      return util.getRecordingFile(models.AudioRecording, req, res);
+    middleware.requestWrapper(async (request, response) => {
+      let { recording, cookedJWT } = await recordingUtil.get(request, "audio");
+      responseUtil.send(response, {
+        statusCode: 200,
+        success: true,
+        messages: [],
+        recording: recording,
+        jwt: cookedJWT,
+      });
     })
   );
 };

--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -1,4 +1,4 @@
-const { query, check }  = require('express-validator/check');
+const { query, param, header }  = require('express-validator/check');
 const moment = require('moment');
 const { format } = require('util');
 
@@ -78,7 +78,7 @@ module.exports = function(app, baseUrl) {
     apiUrl + "/:id",
     [
       middleware.authenticateUser,
-      check('id').isInt(),
+      param('id').isInt(),
       middleware.parseJSON('data'),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -139,8 +139,8 @@ module.exports = function(app, baseUrl) {
     [
       middleware.authenticateUser,
       middleware.parseJSON('where').optional(),
-      check('offset').isInt(),
-      check('limit').isInt(),
+      header('offset').isInt(),
+      header('limit').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
       const qresult = await recordingUtil.query(request, "audio");
@@ -207,7 +207,7 @@ module.exports = function(app, baseUrl) {
     apiUrl + "/:id",
     [
       middleware.authenticateUser,
-      check('id').isInt(),
+      param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
       let { recording, cookedJWT } = await recordingUtil.get(request, "audio");

--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -1,4 +1,4 @@
-const { query, param, header }  = require('express-validator/check');
+const { param, header }  = require('express-validator/check');
 const moment = require('moment');
 const { format } = require('util');
 
@@ -152,7 +152,7 @@ module.exports = function(app, baseUrl) {
       };
 
       // Just save the front end fields for each model.
-      for (let row of qresult.rows) {
+      for (const row of qresult.rows) {
         result.rows.push(getFrontendFields(row));
       }
       responseUtil.validDatapointGet(response, result);
@@ -160,7 +160,7 @@ module.exports = function(app, baseUrl) {
   );
 
   const getFrontendFields = function(rec) {
-    const out = {
+    return {
       id: rec.id,
       recordingDateTime: rec.recordingDateTime,
       relativeToDawn: rec.relativeToDawn,
@@ -178,13 +178,6 @@ module.exports = function(app, baseUrl) {
       group: rec.Group.groupname,
       additionalMetadata: rec.additionalMetadata,
     };
-    if (rec.relativeToDawn) {
-      out.relativeToDawn = rec.relativeToDawn;
-    }
-    if (rec.relativeToDusk) {
-      out.relativeToDusk = rec.relativeToDusk;
-    }
-    return out;
   };
 
   /**
@@ -210,7 +203,7 @@ module.exports = function(app, baseUrl) {
       param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
-      let { recording, cookedJWT } = await recordingUtil.get(request, "audio");
+      const { recording, cookedJWT } = await recordingUtil.get(request, "audio");
       responseUtil.send(response, {
         statusCode: 200,
         success: true,

--- a/api/V1/File.js
+++ b/api/V1/File.js
@@ -6,6 +6,7 @@ const jsonwebtoken      = require('jsonwebtoken');
 const middleware        = require('../middleware');
 const { query }  = require('express-validator/check');
 
+
 module.exports = (app, baseUrl) => {
   var apiUrl = baseUrl + '/files';
 
@@ -31,7 +32,7 @@ module.exports = (app, baseUrl) => {
       middleware.authenticateUser,
     ],
     middleware.requestWrapper(
-      util.multipartUpload('file', (request, data, key) => {
+      util.multipartUpload((request, data, key) => {
         var dbRecord = models.File.build(data, {
           fields: models.File.apiSettableFields,
         });
@@ -53,7 +54,6 @@ module.exports = (app, baseUrl) => {
    *
    * @apiUse V1ResponseSuccessQuery
    */
-
   app.get(
     apiUrl,
     [
@@ -168,7 +168,7 @@ module.exports = (app, baseUrl) => {
         responseUtil.send(response, {
           statusCode: 400,
           success: false,
-          messages: ["Failed to delete file.  Files can only be deleted by the admins and the person who uploaded the file."],
+          messages: ["Failed to delete file. Files can only be deleted by the admins and the person who uploaded the file."],
         });
       }
     })

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -157,7 +157,7 @@ module.exports = (app, baseUrl) => {
       check('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
-      let { recording, rawJWT, cookedJWT } = await recordingUtil.get(request);
+      const { recording, rawJWT, cookedJWT } = await recordingUtil.get(request);
       responseUtil.send(response, {
         statusCode: 200,
         success: true,

--- a/api/V1/Schedule.js
+++ b/api/V1/Schedule.js
@@ -9,12 +9,11 @@ module.exports = (app, baseUrl) => {
    * @api {post} /api/v1/schedules Adds a new schedule
    * @apiName PostSchedule
    * @apiGroup Schedules
-   * @apiDescription This call is used to upload a new audio bait schedule which controls when
-   * sound bait files are played.
+   * @apiDescription This call is used to upload a new audio bait
+   * schedule which controls when sound bait files are played. The
+   * body of the request should contain the schedule in JSON format.
    *
    * @apiUse V1UserAuthorizationHeader
-   *
-   * @apiBody {JSON} data Metadata about the schedule in JSON format.
    *
    * @apiParam {Int[]} devices List of device Ids that schedule should apply to
    * @apiParam {JSON} schedule Schedule

--- a/api/V1/index.js
+++ b/api/V1/index.js
@@ -9,6 +9,7 @@ module.exports = function(app) {
   apiRouts.splice(apiRouts.indexOf('util.js'), 1);
   apiRouts.splice(apiRouts.indexOf('requestUtil.js'), 1);
   apiRouts.splice(apiRouts.indexOf('responseUtil.js'), 1);
+  apiRouts.splice(apiRouts.indexOf('recordingUtil.js'), 1);
   apiRouts.splice(apiRouts.indexOf('tagsUtil.js'), 1);
   apiRouts.splice(apiRouts.indexOf('apidoc.js'), 1);
 

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -1,0 +1,131 @@
+const jsonwebtoken      = require('jsonwebtoken');
+const mime             = require('mime');
+
+const { ClientError }   = require('../customErrors');
+const config            = require('../../config');
+const models            = require('../../models');
+const responseUtil      = require('./responseUtil');
+const util              = require('./util');
+
+
+function makeUploadHandler(mungeData) {
+  return util.multipartUpload((request, data, key) => {
+    if (mungeData) {
+      data = mungeData(data);
+    }
+
+    const recording = models.Recording.build(data, {
+      fields: models.Recording.apiSettableFields,
+    });
+    recording.set('rawFileKey', key);
+    recording.set('rawMimeType', guessRawMimeType(data.type, data.filename));
+    recording.set('DeviceId', request.device.id);
+    recording.set('GroupId', request.device.GroupId);
+    recording.set('processingState', models.Recording.processingStates[data.type][0]);
+    if (typeof request.device.public === 'boolean') {
+      recording.set('public', request.device.public);
+    }
+    return recording;
+  });
+}
+
+// Returns a promise for the recordings query specified in the
+// request.
+function query(request, type) {
+  if (request.query.tagMode == null) {
+    request.query.tagMode = 'any';
+  }
+  if (!request.query.where) {
+    request.query.where = {};
+  }
+
+  // remove legacy tag mode selector (if included)
+  delete request.query.where._tagged;
+
+  if (type) {
+    request.query.where.type = type;
+  }
+
+  return models.Recording.query(
+    request.user,
+    request.query.where,
+    request.query.tagMode,
+    request.query.tags,
+    request.query.offset,
+    request.query.limit,
+    request.query.order);
+}
+
+async function get(request, type) {
+  const recording = await models.Recording.getOne(request.user, request.params.id, type);
+  if (!recording) {
+    throw new ClientError("No file found with given datapoint");
+  }
+
+  const downloadFileData = {
+    _type: 'fileDownload',
+    key: recording.fileKey,
+    filename: recording.getFileName(),
+    mimeType: recording.fileMimeType,
+  };
+
+  const downloadRawData = {
+    _type: 'fileDownload',
+    key: recording.rawFileKey,
+    filename: recording.getRawFileName(),
+    mimeType: recording.rawMimeType,
+  };
+  delete recording.rawFileKey;
+
+  return {
+    recording: recording,
+    cookedJWT: jsonwebtoken.sign(
+      downloadFileData,
+      config.server.passportSecret,
+      { expiresIn: 60 * 10 }
+    ),
+    rawJWT: jsonwebtoken.sign(
+      downloadRawData,
+      config.server.passportSecret,
+      { expiresIn: 60 * 10 }
+    ),
+  };
+}
+
+async function delete_(request, response) {
+  var deleted = await models.Recording.deleteOne(request.user, request.params.id);
+  if (deleted) {
+    responseUtil.send(response, {
+      statusCode: 200,
+      success: true,
+      messages: ["Deleted recording."],
+    });
+  } else {
+    responseUtil.send(response, {
+      statusCode: 400,
+      success: false,
+      messages: ["Failed to delete recording."],
+    });
+  }
+}
+
+function guessRawMimeType(type, filename) {
+  var mimeType = mime.getType(filename);
+  if (mimeType) {
+    return mimeType;
+  }
+  switch (type) {
+  case "thermalRaw":
+    return "application/x-cptv";
+  case "audio":
+    return "audio/mpeg";
+  default:
+    return "application/octet-stream";
+  }
+}
+
+
+exports.makeUploadHandler = makeUploadHandler;
+exports.query = query;
+exports.get = get;
+exports.delete_ = delete_;

--- a/api/V1/signedUrl.js
+++ b/api/V1/signedUrl.js
@@ -1,9 +1,11 @@
-const config       = require('../../config');
-const log          = require('../../logging');
-const responseUtil = require('./responseUtil');
-const stream       = require('stream');
-const modelsUtil   = require('../../models/util/util');
-const middleware   = require('../middleware');
+const stream          = require('stream');
+
+const config          = require('../../config');
+const log             = require('../../logging');
+const middleware      = require('../middleware');
+const modelsUtil      = require('../../models/util/util');
+const responseUtil    = require('./responseUtil');
+const { ClientError } = require('../customErrors');
 
 
 module.exports = function(app, baseUrl) {
@@ -33,6 +35,9 @@ module.exports = function(app, baseUrl) {
       var filename = request.jwtDecoded.filename || "file";
 
       var key = request.jwtDecoded.key;
+      if (!key) {
+        throw new ClientError("no key provided");
+      }
 
       var s3 = modelsUtil.openS3();
       var params = {
@@ -46,7 +51,6 @@ module.exports = function(app, baseUrl) {
           log.error(err.stack);
           return responseUtil.serverError(response, err);
         }
-
 
         if (!request.headers.range) {
           response.setHeader('Content-disposition',

--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -192,7 +192,7 @@ function catchError(error, response, responseFunction) {
   return responseUtil.serverError(response, error);
 }
 
-function multipartUpload(recordTypeName, buildRecord){
+function multipartUpload(buildRecord){
   return (request, response) => {
     var key = uuidv4();
     var data;

--- a/migrations/20180802021921-move-audio-to-recordings.js
+++ b/migrations/20180802021921-move-audio-to-recordings.js
@@ -1,0 +1,57 @@
+'use strict';
+
+module.exports = {
+  up: async function (queryInterface) {
+    // Move audio recordings to Recordings. Leave the source data
+    // alone in case of disaster.
+    await queryInterface.sequelize.query(`
+        INSERT INTO "Recordings" (
+            type,
+            "DeviceId",
+            "GroupId",
+            "additionalMetadata",
+            "airplaneModeOn",
+            "batteryCharging",
+            "batteryLevel",
+            "createdAt",
+            duration,
+            "fileKey",
+            "fileMimeType",
+            "fileSize",
+            location,
+            "processingState",
+            "recordingDateTime",
+            "relativeToDawn",
+            "relativeToDusk",
+            "updatedAt",
+            public,
+            version
+        )
+        SELECT
+            'audio' as type,
+            "DeviceId",
+            "GroupId",
+            "additionalMetadata",
+            "airplaneModeOn",
+            "batteryCharging",
+            "batteryLevel",
+            "createdAt",
+            duration,
+            "fileKey",
+            "mimeType" as "fileMimeType",
+            size as "fileSize",
+            location,
+            'FINISHED' as "processingState",
+            "recordingDateTime",
+            "relativeToDawn",
+            "relativeToDusk",
+            "updatedAt",
+            public,
+            version
+        FROM "AudioRecordings"
+    `);
+  },
+
+  // Do nothing here. Safer to do manual reversal.
+  down: function () {}
+};

--- a/models/AudioRecording.js
+++ b/models/AudioRecording.js
@@ -86,7 +86,6 @@ module.exports = function(sequelize, DataTypes) {
       userCanEdit: util.userCanEdit,
     },
     instanceMethods: {
-      getFrontendFields: getFrontendFields,
       processRecording: util.processAudio,
       saveFile: util.saveFile,
     },
@@ -121,35 +120,6 @@ var apiSettableFields = [
 function addAssociations(models) {
   models.AudioRecording.belongsTo(models.Group);
   models.AudioRecording.hasMany(models.Tag);
-}
-
-function getFrontendFields() {
-  var model = this;
-  var group = null;
-  if (model.dataValues.Group)
-  {group = model.dataValues.Group.dataValues.groupname;}
-  var tags = [];
-  for (var tag in model.getDataValue('Tags'))
-  {tags.push(model.getDataValue('Tags')[tag].getFrontendFields());}
-  return {
-    id: model.getDataValue('id'),
-    recordingDateTime: model.getDataValue('recordingDateTime'),
-    recordingTime: model.getDataValue('recordingTime'),
-    duration: model.getDataValue('duration'),
-    location: model.getDataValue('location'),
-    fileKey: model.getDataValue('fileKey'),
-    batteryCharging: model.get('batteryCharging'),
-    batteryLevel: model.get('batteryLevel'),
-    airplaneModeOn: model.get('airplaneModeOn'),
-    relativeToDawn: model.get('relativeToDawn'),
-    relativeToDusk: model.get('relativeToDusk'),
-    version: model.get('version'),
-    additionalMetadata: model.get('additionalMetadata'),
-    deviceId: model.getDataValue('DeviceId'),
-    groupId: model.getDataValue('GroupId'),
-    group: group,
-    tags: tags,
-  };
 }
 
 function findAllWithUser(user, queryParams) {

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -138,7 +138,7 @@ module.exports = function(sequelize, DataTypes) {
   /**
    * Return a single recording for a user.
    */
-  var getOne = async function(user, id) {
+  var getOne = async function(user, id, type) {
     var query = {
       where: {
         "$and": [
@@ -152,6 +152,9 @@ module.exports = function(sequelize, DataTypes) {
       ],
       attributes: this.userGetAttributes.concat(['rawFileKey']),
     };
+    if (type) {
+      query.where['$and'].push({'type': type});
+    }
 
     return await this.findOne(query);
   };
@@ -245,7 +248,6 @@ module.exports = function(sequelize, DataTypes) {
       isValidTagMode: function(mode) { return validTagModes.includes(mode); },
     },
     instanceMethods: {
-      canGetRaw: canGetRaw,
       getFileName: getFileName,
       getFileExt: getFileExt,
       getRawFileName: getRawFileName,
@@ -293,13 +295,6 @@ function getUserPermissions(user) {
   });
 }
 
-function canGetRaw() {
-  if (this.get('type') == 'thermalRaw') {
-    return true;
-  }
-  return false;
-}
-
 function getFileName() {
   var ext = this.getFileExt();
   return moment(new Date(this.recordingDateTime)).tz("Pacific/Auckland")
@@ -326,6 +321,8 @@ var userGetAttributes = [
   'processingState',
   'duration',
   'recordingDateTime',
+  'relativeToDawn',
+  'relativeToDusk',
   'location',
   'version',
   'batteryLevel',
@@ -342,6 +339,8 @@ var apiSettableFields = [
   'type',
   'duration',
   'recordingDateTime',
+  'relativeToDawn',
+  'relativeToDusk',
   'location',
   'version',
   'batteryCharging',
@@ -355,10 +354,12 @@ var apiSettableFields = [
 var apiUpdatableFields = [
   'location',
   'comment',
+  'additionalMetadata',
 ];
 
 var processingStates = {
   thermalRaw: ['toMp4', 'FINISHED'],
+  audio: ['toMp3', 'FINISHED'],
 };
 
 var processingAttributes = [

--- a/test/test_05_audio_device.py
+++ b/test/test_05_audio_device.py
@@ -9,5 +9,7 @@ class TestAudioDevice:
         print("And 'Listener' should be able to upload an audio file")
         recording = listener.upload_audio_recording()
 
-        print("And the audio recording can be downloaded by the super user")
-        helper.admin_user().can_download_correct_audio_recording(recording)
+        user = helper.admin_user()
+
+        print("And the audio recording can be downloaded by a user")
+        user.can_download_correct_recording(recording)

--- a/test/test_06_user_audio.py
+++ b/test/test_06_user_audio.py
@@ -19,7 +19,7 @@ class TestUserAudio:
 
         print("\nA user should be able to download the audio recording")
         user = helper.admin_user()
-        user.can_download_correct_audio_recording(recording)
+        user.can_download_correct_recording(recording)
 
     def test_can_query_audio_recordings(self, helper):
         print("If a new user clare", end='')
@@ -52,9 +52,11 @@ class TestUserAudio:
 
         print("\nWhen a user updates the audio recording")
         user = helper.admin_user()
-        new_meta = {'foo': 'bar'}
-        user.update_audio_recording(recording, additionalMetadata=new_meta)
+        meta = recording['additionalMetadata']
+        meta['foo'] = 'bar'
+        print(meta)
+        user.update_audio_recording(recording, additionalMetadata=meta)
 
         print("the change should be reflected on the API server")
-        recording['additionalMetadata'] = new_meta
-        user.can_download_correct_audio_recording(recording)
+        print(recording['additionalMetadata'])
+        user.can_download_correct_recording(recording)

--- a/test/test_07_user_thermal.py
+++ b/test/test_07_user_thermal.py
@@ -53,3 +53,14 @@ class TestUserThermal:
         with pytest.raises(OSError, message="On no 'trouble' could upload a recording on behalf of the device!"):
             recording = trouble.uploads_recording_for(device)
 
+    def test_cant_download_recording_via_audio_api(self, helper):
+        device = helper.given_new_device(self, 'user-thermal-download')
+        recording = device.has_recording()
+
+        user = helper.admin_user()
+
+        print("\nA user should not be able to download the recording using the audio API")
+        user.cannot_download_audio(recording)
+
+        print("\nNor be able to see the recording through the audio query API")
+        user.cannot_see_audio_recording(recording)


### PR DESCRIPTION
The pre-existing AudioRecordings API still exists but it now interacts with the Recordings table instead. The AudioRecordings API is now marked as deprecated. Most of the API handler logic for dealing with recordings has been moved out to api/V1/recordingUtil.js so that it can be shared by the Recordings and AudioRecordings APIs.

A DB migration is included which imports all audio recordings into Recordings.