### PR TITLE
Copy AudioRecordings query params from headers to query params

### DIFF
--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -143,6 +143,12 @@ module.exports = function(app, baseUrl) {
       header('limit').isInt().optional(),
     ],
     middleware.requestWrapper(async (request, response) => {
+      // recordingUtil.query expects these as query parameters not
+      // headers so copy them across.
+      request.query.where = request.headers.where;
+      request.query.limit = request.headers.limit;
+      request.query.offset = request.headers.offset;
+
       const qresult = await recordingUtil.query(request, "audio");
       var result = {
         rows: [],

--- a/test/test_06_user_audio.py
+++ b/test/test_06_user_audio.py
@@ -45,6 +45,26 @@ class TestUserAudio:
         print("Clare should be able to see exactly those the recordings")
         clare.can_see_audio_recordings(recordings)
 
+    def test_can_limit_audio_query(self, helper):
+        print("If a new user grace", end='')
+        grace = helper.given_new_user(self, 'grace')
+
+        print("   has a new group called 'area42'", end='')
+        group_name = helper.make_unique_group_name(self, 'area42')
+        grace.create_group(group_name)
+        print("({})".format(group_name))
+
+        description = "  and there is a new device called 'Bobby' in this group"
+        device = helper.given_new_device(self, 'Bobby', group_name, description=description)
+
+        print("When several recordings are uploaded")
+        recordings = []
+        for _ in range(3):
+            recordings.append(device.has_audio_recording())
+            print()
+
+        print("Grace will see just the latest recording if she asks for just one")
+        grace.can_see_audio_recordings(recordings[-1:], limit=1)
 
     def test_can_update_audio(self, helper):
         phone = helper.given_new_device(self, 'phone')

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -161,9 +161,9 @@ class TestUser:
         rows = self._userapi.query_audio()
         assert not rows
 
-    def can_see_audio_recordings(self, recordings):
+    def can_see_audio_recordings(self, recordings, **query_args):
         expected_ids = {rec.recordingId for rec in recordings}
-        actual_ids = {row['id'] for row in self._userapi.query_audio()}
+        actual_ids = {row['id'] for row in self._userapi.query_audio(**query_args)}
         assert actual_ids == expected_ids
 
     def delete_audio_recording(self, recording):

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -1,6 +1,7 @@
 import json
 import os
 import requests
+from collections import defaultdict
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 from urllib.parse import urljoin
 
@@ -12,17 +13,14 @@ class UserAPI(APIBase):
         super().__init__('user', baseurl, username, password)
 
     def query(self, startDate=None, endDate=None, min_secs=0, limit=100, offset=0, tagmode=None, tags=None):
-        where = [{"duration": {"$gte": min_secs}}]
+        where = defaultdict(dict)
+        where["duration"] = {"$gte": min_secs}
         if startDate is not None:
-            where.append({
-                'recordingDateTime': {
-                    '$gte': startDate.isoformat()
-                }
-            })
+            where["recordingDateTime"]['$gte'] = startDate.isoformat()
         if endDate is not None:
-            where.append({'recordingDateTime': {'$lte': endDate.isoformat()}})
-
+            where["recordingDateTime"]['$lte'] = endDate.isoformat()
         params = {'where': json.dumps(where)}
+
         if tagmode is not None:
             params['tagMode'] = tagmode
         if tags is not None:
@@ -64,15 +62,12 @@ class UserAPI(APIBase):
     def query_audio(self, startDate=None, endDate=None, min_secs=0, limit=100, offset=0):
         headers = self._auth_header.copy()
 
-        where = [{"duration": {"$gte": min_secs}}]
+        where = defaultdict(dict)
+        where["duration"] = {"$gte": min_secs}
         if startDate is not None:
-            where.append({
-                'recordingDateTime': {
-                    '$gte': startDate.isoformat()
-                }
-            })
+            where["recordingDateTime"]['$gte'] = startDate.isoformat()
         if endDate is not None:
-            where.append({'recordingDateTime': {'$lte': endDate.isoformat()}})
+            where["recordingDateTime"]['$lte'] = endDate.isoformat()
         headers['where'] = json.dumps(where)
 
         if limit is not None:


### PR DESCRIPTION
recordingUtil.query() only looks in query params which meant the limit, offset and where fields were being ignored.

Also fixed how `where` params are sent to the API server by the tests. The tests where using an undocumented way of doing this which didn't match what the UI uses.