### PR TITLE
Tidy up middleware checks.

### DIFF
--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-const { param, header }  = require('express-validator/check');
+const { param, header, body }  = require('express-validator/check');
 const moment = require('moment');
 const { format } = require('util');
 
@@ -97,7 +97,7 @@ module.exports = function(app, baseUrl) {
     [
       middleware.authenticateUser,
       param('id').isInt(),
-      middleware.parseJSON('data'),
+      middleware.parseJSON('data', body),
     ],
     middleware.requestWrapper(async (request, response) => {
       var updated = await models.Recording.updateOne(
@@ -126,6 +126,7 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/:id',
     [
       middleware.authenticateUser,
+      param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
       await recordingUtil.delete_(request, response);
@@ -156,7 +157,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where').optional(),
+      middleware.parseJSON('where', header).optional(),
       header('offset').isInt().optional(),
       header('limit').isInt().optional(),
     ],

--- a/api/V1/AuthenticateDevice.js
+++ b/api/V1/AuthenticateDevice.js
@@ -38,7 +38,7 @@ module.exports = function(app) {
   app.post(
     '/authenticate_device',
     [
-      middleware.getDeviceByName,
+      middleware.getDeviceByName(body),
       body('password').exists(),
     ],
     middleware.requestWrapper(async (request, response) => {

--- a/api/V1/AuthenticateUser.js
+++ b/api/V1/AuthenticateUser.js
@@ -40,7 +40,7 @@ module.exports = function(app) {
     '/authenticate_user',
     [
       oneOf([
-        middleware.getUserByName,
+        middleware.getUserByName(body),
         middleware.getUserByEmail,
       ],
       "could not find a user with the given username or email"),

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -21,7 +21,7 @@ const jwt          = require('jsonwebtoken');
 const config       = require('../../config');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
-const { check }    = require('express-validator/check');
+const { body }     = require('express-validator/check');
 
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/devices';
@@ -46,7 +46,7 @@ module.exports = function(app, baseUrl) {
       middleware.checkNewName('devicename')
         .custom(value => { return models.Device.freeDevicename(value); }),
       middleware.checkNewPassword('password'),
-      middleware.getGroupByName,
+      middleware.getGroupByName(body),
     ],
     middleware.requestWrapper(async (request, response) => {
       const device = await models.Device.create({
@@ -112,7 +112,7 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
       middleware.getDeviceById,
       middleware.getUserById,
-      check('admin').isIn([true, false]),
+      body('admin').isIn([true, false]),
     ],
     middleware.requestWrapper(async (request, response) => {
       var added = await models.Device.addUserToDevice(
@@ -158,8 +158,8 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/users',
     [
       middleware.authenticateUser,
-      middleware.getUserById,
-      middleware.getDeviceById,
+      middleware.getUserById(body),
+      middleware.getDeviceById(body),
     ],
     middleware.requestWrapper(async function(request, response) {
       var removed = await models.Device.removeUserFromDevice(

--- a/api/V1/Event.js
+++ b/api/V1/Event.js
@@ -52,7 +52,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateDevice,
-      middleware.getEventDetailById.optional(),
+      middleware.getEventDetailById(body).optional(),
       middleware.isDateArray("dateTimes", "List of times event occured is required."),
       oneOf([
         body("eventDetailId").exists(),
@@ -126,10 +126,10 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where'),
+      middleware.parseJSON('where', query),
       query('offset').isInt().optional(),
       query('limit').isInt().optional(),
-      middleware.parseJSON('order').optional(),
+      middleware.parseJSON('order', query).optional(),
     ],
     middleware.requestWrapper(async (request, response) => {
 

--- a/api/V1/File.js
+++ b/api/V1/File.js
@@ -22,7 +22,7 @@ const responseUtil      = require('./responseUtil');
 const config            = require('../../config');
 const jsonwebtoken      = require('jsonwebtoken');
 const middleware        = require('../middleware');
-const { query }  = require('express-validator/check');
+const { query, param }  = require('express-validator/check');
 
 
 module.exports = (app, baseUrl) => {
@@ -76,10 +76,10 @@ module.exports = (app, baseUrl) => {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where'),
+      middleware.parseJSON('where', query),
       query('offset').isInt().optional(),
       query('limit').isInt().optional(),
-      middleware.parseJSON('order').optional(),
+      middleware.parseJSON('order', query).optional(),
     ],
     middleware.requestWrapper(async (request, response) => {
 
@@ -128,7 +128,7 @@ module.exports = (app, baseUrl) => {
     apiUrl + '/:id',
     [
       middleware.authenticateAny,
-      middleware.getFileById,
+      middleware.getFileById(param),
     ],
     middleware.requestWrapper(async (request, response) => {
 
@@ -171,7 +171,7 @@ module.exports = (app, baseUrl) => {
     apiUrl + '/:id',
     [
       middleware.authenticateUser,
-      middleware.getFileById,
+      middleware.getFileById(param),
     ],
     middleware.requestWrapper(async (request, response) => {
 

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const models       = require('../../models');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
-const { check, query, body } = require('express-validator/check');
+const { query, body } = require('express-validator/check');
 
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/groups';
@@ -112,7 +112,7 @@ module.exports = function(app, baseUrl) {
       middleware.authenticateUser,
       middleware.getGroupById(body),
       middleware.getUserById(body),
-      check('admin').isBoolean(),
+      body('admin').isBoolean(),
     ],
     middleware.requestWrapper(async (request, response) => {
 

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const models       = require('../../models');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
-const { check }    = require('express-validator/check');
+const { check, query, body } = require('express-validator/check');
 
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/groups';
@@ -75,7 +75,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where')
+      middleware.parseJSON('where', query),
     ],
     middleware.requestWrapper(async (request, response) => {
 
@@ -110,8 +110,8 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/users',
     [
       middleware.authenticateUser,
-      middleware.getGroupById,
-      middleware.getUserById,
+      middleware.getGroupById(body),
+      middleware.getUserById(body),
       check('admin').isBoolean(),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -157,8 +157,8 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/users',
     [
       middleware.authenticateUser,
-      middleware.getUserById,
-      middleware.getGroupById,
+      middleware.getUserById(body),
+      middleware.getGroupById(body),
     ],
     middleware.requestWrapper(async (request, response) => {
 

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-const { query, check } = require('express-validator/check');
+const { query, param, body } = require('express-validator/check');
 
 const middleware        = require('../middleware');
 const models            = require('../../models');
@@ -93,7 +93,7 @@ module.exports = (app, baseUrl) => {
     apiUrl + "/:devicename",
     [
       middleware.authenticateUser,
-      middleware.getDeviceByName,
+      middleware.getDeviceByName(param),
     ],
     middleware.ifUsersDeviceRequestWrapper(
       recordingUtil.makeUploadHandler()
@@ -128,11 +128,11 @@ module.exports = (app, baseUrl) => {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where'),
+      middleware.parseJSON('where', query),
       query('offset').isInt(),
       query('limit').isInt(),
-      middleware.parseJSON('order').optional(),
-      middleware.parseArray('tags').optional(),
+      middleware.parseJSON('order', query).optional(),
+      middleware.parseArray('tags', query).optional(),
       query('tagMode')
         .optional()
         .custom(value => { return models.Recording.isValidTagMode(value); }),
@@ -172,7 +172,7 @@ module.exports = (app, baseUrl) => {
     apiUrl + '/:id',
     [
       middleware.authenticateUser,
-      check('id').isInt(),
+      param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
       const { recording, rawJWT, cookedJWT } = await recordingUtil.get(request);
@@ -201,7 +201,7 @@ module.exports = (app, baseUrl) => {
     apiUrl + '/:id',
     [
       middleware.authenticateUser,
-      check('id').isInt(),
+      param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
       return recordingUtil.delete_(request, response);
@@ -234,8 +234,8 @@ module.exports = (app, baseUrl) => {
     apiUrl + '/:id',
     [
       middleware.authenticateUser,
-      check('id').isInt(),
-      middleware.parseJSON('updates'),
+      param('id').isInt(),
+      middleware.parseJSON('updates', body),
     ],
     middleware.requestWrapper(async (request, response) => {
       var updated = await models.Recording.updateOne(

--- a/api/V1/Schedule.js
+++ b/api/V1/Schedule.js
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+const { body, param } = require('express-validator/check');
 const models = require('../../models');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
@@ -43,8 +44,8 @@ module.exports = (app, baseUrl) => {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseArray('devices'),
-      middleware.parseJSON('schedule'),
+      middleware.parseArray('devices', body),
+      middleware.parseJSON('schedule', body),
     ],
     middleware.ifUsersDeviceRequestWrapper(async function(request, response) {
       var deviceIds = request.body.devices;
@@ -107,7 +108,7 @@ module.exports = (app, baseUrl) => {
     apiUrl + "/:devicename",
     [
       middleware.authenticateUser,
-      middleware.getDeviceByName,
+      middleware.getDeviceByName(param),
     ],
     middleware.ifUsersDeviceRequestWrapper(async (request, response) => {
       getSchedule(request.device, response, request.user);

--- a/api/V1/Tag.js
+++ b/api/V1/Tag.js
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-const { check, body } = require('express-validator/check');
+const { body } = require('express-validator/check');
 
 const middleware = require('../middleware');
 const models = require('../../models');
@@ -63,7 +63,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('tag'),
+      middleware.parseJSON('tag', body),
       body('recordingId').isInt(),
     ],
     middleware.requestWrapper(async function(request, response) {
@@ -76,7 +76,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateUser,
-      check('tagId').isInt(),
+      body('tagId').isInt(),
     ],
     middleware.requestWrapper(async function(request, response) {
 

--- a/api/V1/User.js
+++ b/api/V1/User.js
@@ -21,7 +21,7 @@ const jwt          = require('jsonwebtoken');
 const config       = require('../../config');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
-const { body }     = require('express-validator/check');
+const { body, param } = require('express-validator/check');
 const { ClientError } = require('../customErrors');
 
 module.exports = function(app, baseUrl) {
@@ -88,7 +88,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('data'),
+      middleware.parseJSON('data', body),
     ],
     middleware.requestWrapper(async (request, response) => {
       const email = request.body.data.email;
@@ -125,7 +125,7 @@ module.exports = function(app, baseUrl) {
     apiUrl + "/:username",
     [
       middleware.authenticateUser,
-      middleware.getUserByName,
+      middleware.getUserByName(param),
     ],
     middleware.requestWrapper(async (request, response) => {
       return responseUtil.send(response, {

--- a/api/fileProcessing/index.js
+++ b/api/fileProcessing/index.js
@@ -151,7 +151,7 @@ module.exports = function(app) {
   app.post(
     apiUrl + "/tags",
     [
-      middleware.parseJSON('tag'),
+      middleware.parseJSON('tag', body),
       body('recordingId').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {

--- a/api/middleware.js
+++ b/api/middleware.js
@@ -23,7 +23,7 @@ const format       = require('util').format;
 const ExtractJwt   = require('passport-jwt').ExtractJwt;
 const log          = require('../logging');
 const customErrors = require('./customErrors');
-const { body, check, header, validationResult, query } = require('express-validator/check');
+const { body, header, validationResult, query } = require('express-validator/check');
 /*
  * Authenticate a JWT in the 'Authorization' header of the given type
  */
@@ -82,7 +82,7 @@ const signedUrl = query('jwt').custom((value, {req}) => {
 });
 
 
-const getModelById = function(modelType, fieldName, checkFunc=check) {
+const getModelById = function(modelType, fieldName, checkFunc) {
   return checkFunc(fieldName).custom(async (val, { req }) => {
     const model = await modelType.findById(val);
     if (model === null) {
@@ -93,7 +93,7 @@ const getModelById = function(modelType, fieldName, checkFunc=check) {
   });
 };
 
-const getModelByName = function(modelType, fieldName, checkFunc=check) {
+const getModelByName = function(modelType, fieldName, checkFunc) {
   return checkFunc(fieldName).custom(async (val, { req }) => {
     const model = await modelType.getFromName(val);
     if (model === null) {
@@ -134,18 +134,37 @@ const isDateArray = function(fieldName, customError) {
   });
 };
 
-const getUserById = getModelById(models.User, 'userId');
-const getUserByName = getModelByName(models.User, 'username');
+function getUserById(checkFunc) {
+  return getModelById(models.User, 'userId', checkFunc);
+}
 
-const getGroupById = getModelById(models.Group, 'groupId');
-const getGroupByName = getModelByName(models.Group, 'group');
+function getUserByName(checkFunc) {
+  return getModelByName(models.User, 'username', checkFunc);
+}
 
-const getDeviceById = getModelById(models.Device, 'deviceId');
-const getDeviceByName = getModelByName(models.Device, 'devicename');
+function getGroupById(checkFunc) {
+  return getModelById(models.Group, 'groupId', checkFunc);
+}
 
-const getEventDetailById = getModelById(models.EventDetail, 'eventDetailId');
+function getGroupByName(checkFunc) {
+  return getModelByName(models.Group, 'group', checkFunc);
+}
 
-const getFileById = getModelById(models.File, 'id');
+function getDeviceById(checkFunc) {
+  return getModelById(models.Device, 'deviceId', checkFunc);
+}
+
+function getDeviceByName(checkFunc) {
+  return getModelByName(models.Device, 'devicename', checkFunc);
+}
+
+function getEventDetailById(checkFunc) {
+  return getModelById(models.EventDetail, 'eventDetailId', checkFunc);
+}
+
+function getFileById(checkFunc) {
+  return getModelById(models.File, 'id', checkFunc);
+}
 
 const checkNewName = function(field) {
   return body(field, 'invalid name')
@@ -158,8 +177,8 @@ const checkNewPassword = function(field) {
     .isLength({ min: 8 });
 };
 
-const parseJSON = function(field) {
-  return check(field).custom((value, {req, location, path}) => {
+const parseJSON = function(field, checkFunc) {
+  return checkFunc(field).custom((value, {req, location, path}) => {
     try {
       req[location][path] = JSON.parse(value);
       return true;
@@ -169,8 +188,8 @@ const parseJSON = function(field) {
   });
 };
 
-const parseArray = function(field) {
-  return check(field).custom((value, {req, location, path}) => {
+const parseArray = function(field, checkFunc) {
+  return checkFunc(field).custom((value, {req, location, path}) => {
     var arr;
     try {
       arr = JSON.parse(value);


### PR DESCRIPTION
This removes the uses of the general `check` function and uses more specific express-validator functions like `param` `header` `body` `query`
https://express-validator.github.io/docs/check-api.html