### PR TITLE
Catch unhandled error

### DIFF
--- a/api/V1/Tag.js
+++ b/api/V1/Tag.js
@@ -67,7 +67,7 @@ module.exports = function(app, baseUrl) {
       body('recordingId').isInt(),
     ],
     middleware.requestWrapper(async function(request, response) {
-      recordingUtil.addTag(request, response);
+      await recordingUtil.addTag(request, response);
     })
   );
 


### PR DESCRIPTION
Using `await` means that the `requestWrapper` function will catch errors and send a response back. When not using `await` the request would hang then the client would timeout.