### PR TITLE
Add db-migrate scripts target

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
-    "apidoc": "apidoc -i api/V1/ -o apidoc/"
+    "apidoc": "apidoc -i api/V1/ -o apidoc/",
+    "db-migrate": "sequelize db:migrate"
   }
 }


### PR DESCRIPTION
This allows us to run database migrations with `npm run db-migrate`.