### PR TITLE
 Add API to return details of users who can access a device 

### DIFF
--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -90,6 +90,59 @@ module.exports = function(app, baseUrl) {
   );
 
   /**
+  * @api {get} /api/v1/devices/users Get all users who can access a device.
+  * @apiName GetDeviceUsers
+  * @apiGroup Device
+  * @apiDescription Returns all users that have access to the device
+  * through both group membership and direct assignment.
+  *
+  * @apiUse V1UserAuthorizationHeader
+  *
+  * @apiParam {Number} deviceId ID of the device.
+  *
+  * @apiUse V1ResponseSuccess
+  * @apiSuccess {JSON} rows Array of users who have access to the
+  * device. Each element includes `id` (user id), `username`, `email`,
+  * `relation` (either `group` or `device`) and `admin` (boolean).
+  * @apiUse V1ResponseError
+  */
+  app.get(
+    apiUrl + '/users',
+    [
+      middleware.authenticateUser,
+      middleware.getDeviceById(body),
+    ],
+    middleware.requestWrapper(async (request, response) => {
+      let users = await request.body.device.users(request.user);
+
+      users = users.map(u => {
+        u = u.get({ plain: true });
+
+        // Extract the useful parts from DeviceUsers/GroupUsers.
+        if (u.DeviceUsers) {
+          u.relation = "device";
+          u.admin = u.DeviceUsers.admin;
+          delete u.DeviceUsers;
+        } else if (u.GroupUsers) {
+          u.relation = "group";
+          u.admin = u.GroupUsers.admin;
+          delete u.GroupUsers;
+        }
+
+        return u;
+      });
+
+      return responseUtil.send(response, {
+        statusCode: 200,
+        success: true,
+        messages: ["OK."],
+        rows: users
+      });
+    })
+  );
+
+
+  /**
   * @api {post} /api/v1/devices/users Add a user to a device.
   * @apiName AddUserToDevice
   * @apiGroup Device

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -21,7 +21,7 @@ const jwt          = require('jsonwebtoken');
 const config       = require('../../config');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
-const { body }     = require('express-validator/check');
+const { query, body }     = require('express-validator/check');
 
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/devices';
@@ -110,7 +110,7 @@ module.exports = function(app, baseUrl) {
     apiUrl + '/users',
     [
       middleware.authenticateUser,
-      middleware.getDeviceById(body),
+      middleware.getDeviceById(query),
     ],
     middleware.requestWrapper(async (request, response) => {
       let users = await request.body.device.users(request.user);

--- a/models/Device.js
+++ b/models/Device.js
@@ -229,16 +229,6 @@ module.exports = function(sequelize, DataTypes) {
     });
   };
 
-  Device.prototype.userPermissions = async function(user) {
-    if (user.hasGlobalWrite()) {
-      return Device.newUserPermissions(true);
-    }
-
-    const isGroupAdmin = await models.GroupUsers.isAdmin(this.groupId, user.id);
-    const isDeviceAdmin = await models.DeviceUsers.isAdmin(this.id, user.id);
-    return Device.newUserPermissions(isGroupAdmin || isDeviceAdmin);
-  };
-
   // Returns users that have access to this device either via group
   // membership or direct assignment. By default, only "safe" user
   // attributes are returned.

--- a/test/test_13_device_users.py
+++ b/test/test_13_device_users.py
@@ -47,3 +47,34 @@ class TestDeviceUsers:
             OSError, message=["Expected failed to remove user from device."]
         ):
             violet.remove_from_device(helper.admin_user(), shaker)
+
+    def test_can_list_device_users(self, helper):
+        admin_user = helper.admin_user()
+
+        # A new device has just the admin user as a group user.
+        device = helper.given_new_device(self, "Zoe")
+        admin_user.device_has_group_users(device, admin_user)
+        admin_user.device_has_device_users(device)
+
+        # Now add a user and see that it's reported.
+        samantha = helper.given_new_user(self, "Samantha")
+        admin_user.add_to_device(samantha, device)
+        admin_user.device_has_device_users(device, samantha)
+
+        # Now add a another device user and see that both users are reported.
+        bobby = helper.given_new_user(self, "Bobby")
+        admin_user.add_to_device(bobby, device)
+        admin_user.device_has_device_users(device, samantha, bobby)
+
+    def test_random_user_cant_list_group(self, helper):
+        admin_user = helper.admin_user()
+
+        # Set up a device with a group user (admin) and another user.
+        device = helper.given_new_device(self, "sentinel")
+        admin_user.add_to_device(helper.given_new_user(self, "Samantha"), device)
+
+        # Ensure another user who is not a member of the group can't
+        # list the users.
+        hacker = helper.given_new_user(self, "Hacker")
+        hacker.device_has_group_users(device)
+        hacker.device_has_device_users(device)

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -269,6 +269,16 @@ class TestUser:
     def remove_from_device(self, olduser, device):
         self._userapi.remove_user_from_device(olduser, device.get_id())
 
+    def device_has_device_users(self, device, *users):
+        assert self._get_device_users(device, "device") == {u.username for u in users}
+
+    def device_has_group_users(self, device, *users):
+        assert self._get_device_users(device, "group") == {u.username for u in users}
+
+    def _get_device_users(self, device, relation):
+        users = self._userapi.list_device_users(device.get_id())
+        return {u["username"] for u in users if u["relation"] == relation}
+
 
 class RecordingQueryPromise:
     def __init__(self, testUser, queryParams):

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -282,8 +282,7 @@ class UserAPI(APIBase):
 
     def list_device_users(self, deviceid):
         url = urljoin(self._baseurl, "/api/v1/devices/users")
-        props = {
-            "deviceId" : deviceid,
-        }
-        response = requests.get(url, headers=self._auth_header, data=props)
+        response = requests.get(
+            url, headers=self._auth_header, params={"deviceId": deviceid}
+        )
         return self._check_response(response).get("rows", [])

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -279,3 +279,11 @@ class UserAPI(APIBase):
         props = {"deviceId": deviceid, "username": olduser.username}
         response = requests.delete(url, headers=self._auth_header, data=props)
         self._check_response(response)
+
+    def list_device_users(self, deviceid):
+        url = urljoin(self._baseurl, "/api/v1/devices/users")
+        props = {
+            "deviceId" : deviceid,
+        }
+        response = requests.get(url, headers=self._auth_header, data=props)
+        return self._check_response(response).get("rows", [])


### PR DESCRIPTION
`GET /api/V1/devices/users`
This can be called by any user who has admin privs for the device.

Also removed duplicated Device.userPermissions method.