### PR TITLE
Tidy up Events api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ script:
  - npm run lint
  - test/check-style
  - ./wait-for-api || { docker ps; docker logs cacophony-api; exit 1; }
- - cd test && pytest -s
+ - cd test && pytest

--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -141,9 +141,9 @@ module.exports = function(app, baseUrl) {
   *
   * @apiUse V1UserAuthorizationHeader
   *
-  * @apiHeader {String} where [Sequelize where conditions](http://docs.sequelizejs.com/manual/tutorial/querying.html#where) for query
-  * @apiHeader {Number} offset Query result offset (for paging).
-  * @apiHeader {Number} limit Query result limit (for paging).
+  * @apiHeader {String} [where] [Sequelize where conditions](http://docs.sequelizejs.com/manual/tutorial/querying.html#where) for query
+  * @apiHeader {Number} [offset] Query result offset (for paging).
+  * @apiHeader {Number} [limit] Query result limit (for paging).
   *
   * @apiUse V1ResponseSuccess
   * @apiSuccess {Number} offset Mirrors request offset parameter.

--- a/api/V1/Event.js
+++ b/api/V1/Event.js
@@ -21,6 +21,7 @@ const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
 const { body, query, oneOf } = require('express-validator/check');
 
+
 module.exports = function(app, baseUrl) {
   var apiUrl = baseUrl + '/events';
 
@@ -111,7 +112,7 @@ module.exports = function(app, baseUrl) {
   );
 
   /**
-   * @api {get} /api/v1/events Query events recorded
+   * @api {get} /api/v1/events Query recorded events
    * @apiName QueryEvents
    * @apiGroup Events
    *
@@ -127,33 +128,28 @@ module.exports = function(app, baseUrl) {
     [
       middleware.authenticateUser,
       middleware.parseJSON('where', query),
-      query('offset').isInt().optional(),
-      query('limit').isInt().optional(),
+      query('offset').isInt().optional().toInt(),
+      query('limit').isInt().optional().toInt(),
       middleware.parseJSON('order', query).optional(),
     ],
     middleware.requestWrapper(async (request, response) => {
-
-      if (request.query.offset == null) {
-        request.query.offset = '0';
-      }
-
-      if (request.query.offset == null) {
-        request.query.limit = '100';
-      }
+      const query = request.query;
+      query.offset = query.offset || 0;
+      query.limit = query.limit || 100;
 
       var result = await models.Event.query(
         request.user,
-        request.query.where,
-        request.query.offset,
-        request.query.limit,
-        request.query.order);
+        query.where,
+        query.offset,
+        query.limit,
+        query.order);
 
       return responseUtil.send(response, {
         statusCode: 200,
         success: true,
         messages: ["Completed query."],
-        limit: request.query.limit,
-        offset: request.query.offset,
+        limit: query.limit,
+        offset: query.offset,
         count: result.count,
         rows: result.rows,
       });

--- a/api/V1/Event.js
+++ b/api/V1/Event.js
@@ -117,11 +117,11 @@ module.exports = function(app, baseUrl) {
    * @apiGroup Events
    *
    * @apiUse V1UserAuthorizationHeader
-   * @apiParam {Datetime} startTime Return only events after this time (optional)
-   * @apiParam {Datetime} endTime Return only events from before this time (optional)
-   * @apiParam {Integer} deviceId Return only events for this device id (optional)
-   * @apiParam {Integer} limit Limit returned events to this number (default is 100) (optional)
-   * @apiParam {Integer} offset Offset returned events by this amount (default is 0) (optional)
+   * @apiParam {Datetime} [startTime] Return only events after this time
+   * @apiParam {Datetime} [endTime] Return only events from before this time
+   * @apiParam {Integer} [deviceId] Return only events for this device id
+   * @apiParam {Integer} [limit] Limit returned events to this number (default is 100)
+   * @apiParam {Integer} [offset] Offset returned events by this amount (default is 0)
    *
    * @apiSuccess {JSON} rows Array containing details of events matching the criteria given.
    * @apiUse V1ResponseError

--- a/api/V1/Event.js
+++ b/api/V1/Event.js
@@ -45,7 +45,7 @@ module.exports = function(app, baseUrl) {
    * @apiParam {JSON} data Metadata about the recording (see above).
    *
    * @apiUse V1ResponseSuccess
-   * @apiSuccess {Integer} eventsAdded Numbeer of events added
+   * @apiSuccess {Integer} eventsAdded Number of events added
    * @apiSuccess {Integer} eventDetailId Id of the Event Detail record used.  May be existing or newly created
    * @apiuse V1ResponseError
    */
@@ -117,20 +117,24 @@ module.exports = function(app, baseUrl) {
    * @apiGroup Events
    *
    * @apiUse V1UserAuthorizationHeader
+   * @apiParam {Datetime} startTime Return only events after this time (optional)
+   * @apiParam {Datetime} endTime Return only events from before this time (optional)
+   * @apiParam {Integer} deviceId Return only events for this device id (optional)
+   * @apiParam {Integer} limit Limit returned events to this number (default is 100) (optional)
+   * @apiParam {Integer} offset Offset returned events by this amount (default is 0) (optional)
    *
-   * @apiUse QueryParams
-   *
+   * @apiSuccess {JSON} rows Array containing details of events matching the criteria given.
    * @apiUse V1ResponseError
    */
-
   app.get(
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where', query),
+      query('startTime').isISO8601({ strict: true }).optional(),
+      query('endTime').isISO8601({ strict: true }).optional(),
+      query('deviceId').isInt().optional().toInt(),
       query('offset').isInt().optional().toInt(),
       query('limit').isInt().optional().toInt(),
-      middleware.parseJSON('order', query).optional(),
     ],
     middleware.requestWrapper(async (request, response) => {
       const query = request.query;
@@ -139,10 +143,11 @@ module.exports = function(app, baseUrl) {
 
       var result = await models.Event.query(
         request.user,
-        query.where,
+        query.startTime,
+        query.endTime,
+        query.deviceId,
         query.offset,
-        query.limit,
-        query.order);
+        query.limit);
 
       return responseUtil.send(response, {
         statusCode: 200,

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -108,8 +108,8 @@ module.exports = (app, baseUrl) => {
    * @apiUse V1UserAuthorizationHeader
    *
    * @apiUse QueryParams
-   * @apiParam {JSON} tags Only return recordings tagged with one or more of the listed tags (JSON array).
-   * @apiParam {String} tagMode Only return recordings with specific types of tags. Valid values:
+   * @apiParam {JSON} [tags] Only return recordings tagged with one or more of the listed tags (JSON array).
+   * @apiParam {String} [tagMode] Only return recordings with specific types of tags. Valid values:
    * <ul>
    * <li>any: match recordings with any (or no) tag
    * <li>untagged: match only recordings with no tags
@@ -129,9 +129,9 @@ module.exports = (app, baseUrl) => {
     apiUrl,
     [
       middleware.authenticateUser,
-      middleware.parseJSON('where', query),
-      query('offset').isInt(),
-      query('limit').isInt(),
+      middleware.parseJSON('where', query).optional(),
+      query('offset').isInt().optional(),
+      query('limit').isInt().optional(),
       middleware.parseJSON('order', query).optional(),
       middleware.parseArray('tags', query).optional(),
       query('tagMode')

--- a/api/V1/apidoc.js
+++ b/api/V1/apidoc.js
@@ -22,14 +22,14 @@
 
 /**
  * @apiDefine QueryParams
- * @apiParam {JSON} where Selection criteria as a map of keys and requried value, or a list of possible values.
+ * @apiParam {JSON} [where] Selection criteria as a map of keys and requried value, or a list of possible values.
  * * For example {"device": 1}  or {"name": ["bob", "charles"]}.
  * * All matches must be exact.
  * * Records must match all criteria.
  * * Use a '.' to join keys embeded in other keys.  For example, use {"details.name": "sample"}
  * to match { "details": {"name": "sample"}}.  Note: Only some embeded keys will work.
- * @apiParam {Number} offset Zero-based page number. Use '0' to get the first page.  Each page has 'limit' number of records.
- * @apiParam {Number} limit Max number of records to be returned.
+ * @apiParam {Number} [offset] Zero-based page number. Use '0' to get the first page.  Each page has 'limit' number of records.
+ * @apiParam {Number} [limit] Max number of records to be returned.
  * @apiParam {JSON} [order] Sorting order for records.
  * * For example, ["dateTime"] or [["dateTime", "ASC"]].
 */

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -50,19 +50,18 @@ function makeUploadHandler(mungeData) {
 // Returns a promise for the recordings query specified in the
 // request.
 function query(request, type) {
-  if (request.query.tagMode == null) {
+  if (!request.query.tagMode) {
     request.query.tagMode = 'any';
   }
   if (!request.query.where) {
     request.query.where = {};
   }
-
-  // remove legacy tag mode selector (if included)
-  delete request.query.where._tagged;
-
   if (type) {
     request.query.where.type = type;
   }
+
+  // remove legacy tag mode selector (if included)
+  delete request.query.where._tagged;
 
   return models.Recording.query(
     request.user,

--- a/api/middleware.js
+++ b/api/middleware.js
@@ -223,7 +223,7 @@ const parseJSON = function(field, checkFunc) {
       req[location][path] = JSON.parse(value);
       return true;
     } catch(e) {
-      throw new Error(format('Could not parse field %s to a JSON.', path));
+      throw new Error(format('Could not parse JSON field %s.', path));
     }
   });
 };
@@ -234,7 +234,7 @@ const parseArray = function(field, checkFunc) {
     try {
       arr = JSON.parse(value);
     } catch(e) {
-      throw new Error(format('Could not parse field %s to a JSON.', path));
+      throw new Error(format('Could not parse JSON field %s.', path));
     }
     if (Array.isArray(arr)) {
       req[location][path] = arr;

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -89,7 +89,13 @@ module.exports = function(sequelize, DataTypes) {
     * arguments given.
     */
   Recording.query = async function(user, where, tagMode, tags, offset, limit, order, filterOptions) {
-    if (order == null) {
+    if (!offset) {
+      offset = 0;
+    }
+    if (!limit) {
+      limit = 300;
+    }
+    if (!order) {
       order = [
         // Sort by recordingDatetime but handle the case of the
         // timestamp being missing and fallback to sorting by id.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,15 +46,6 @@
         }
       }
     },
-    "@types/body-parser": {
-      "version": "1.16.8",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
-      "integrity": "sha512-BdN2PXxOFnTXFcyONPW6t0fHjz2fvRZHVMFpaS0wYr+Y8fWEaNOs4V8LEu/fpzQlMx+ahdndgTaGTwPC+J/EeA==",
-      "requires": {
-        "@types/express": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/commander": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
@@ -63,39 +54,10 @@
         "commander": "*"
       }
     },
-    "@types/events": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
-      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw=="
-    },
-    "@types/express": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
-      "integrity": "sha512-dBUam7jEjyuEofigUXCtublUHknRZvcRgITlGsTbFgPvnTwtQUt2NgLakbsf+PsGo/Nupqr3IXCYsOpBpofyrA==",
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
-      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
-      "requires": {
-        "@types/events": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/geojson": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-1.0.6.tgz",
       "integrity": "sha512-Xqg/lIZMrUd0VRmSRbCAewtwGZiAk3mEUDvV4op1tGl+LvyPcb/MIOSxTl9z+9+J+R4/vpjiCAT4xeKzH9ji1w=="
-    },
-    "@types/mime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
     },
     "@types/node": {
       "version": "9.3.0",
@@ -106,15 +68,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ=="
-    },
-    "@types/serve-static": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
-      "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
-      }
     },
     "abbrev": {
       "version": "1.1.0",
@@ -1203,20 +1156,12 @@
       }
     },
     "express-validator": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-4.3.0.tgz",
-      "integrity": "sha512-EYU+JJ2EoLpcw+GKwbB1K8UGb/w1A70Wf3gD/zE9QScQxeSt8qad93lxGtsLwZFoiYM0EByVoSzHJnskp+eVHQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-5.3.0.tgz",
+      "integrity": "sha512-HYVtPt21zp2bHS4+xwxYNF63dlq/23kh+ZRVfyo7SBObhOpRyZ0vWolm/v9KPUfCyLqX8j7ZP42dbB0MWjCCcA==",
       "requires": {
-        "@types/express": "~4.0.34",
-        "lodash": "^4.16.0",
-        "validator": "~8.2.0"
-      },
-      "dependencies": {
-        "validator": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
-          "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA=="
-        }
+        "lodash": "^4.17.10",
+        "validator": "^10.4.0"
       }
     },
     "express-winston": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "body-parser": "^1.18.2",
     "commander": "^2.15.1",
     "express": "^4.16.3",
-    "express-validator": "^4.3.0",
+    "express-validator": "^5.3.0",
     "express-winston": "^2.5.0",
     "fs": "0.0.2",
     "install": "^0.12.1",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,8 @@ pytest fixtures defined in conftest.py are automatically loaded and
 made available for use within tests.
 """
 
+import subprocess
+
 import pytest
 
 from .helper import Helper
@@ -23,3 +25,25 @@ def helper():
 @pytest.fixture(scope="module")
 def file_processing(test_config):
     return FileProcessingAPI(test_config.fileprocessing_url)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    "Include recent log output from the API server in the test failures"
+
+    outcome = yield
+    rep = outcome.get_result()
+
+    if rep.when == "call" and rep.failed:
+        try:
+            proc = subprocess.run(
+                ["docker", "logs", "--tail", "50", "cacophony-api"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                check=False,  # this is allowed to fail (perhaps API server is not running in docker)
+                universal_newlines=True,
+            )
+        except FileNotFoundError:
+            return
+        if proc.returncode == 0:
+            rep.sections.append(("Recent API server logs", proc.stdout))

--- a/test/deviceapi.py
+++ b/test/deviceapi.py
@@ -22,13 +22,15 @@ class DeviceAPI(APIBase):
         return self._upload("/api/v1/audiorecordings", filename, props)
 
     def record_event_data(self, eventData, times):
-        eventData["dateTimes"] = times
+        eventData["dateTimes"] = [t.isoformat() for t in times]
         url = urljoin(self._baseurl, "/api/v1/events")
         response = requests.post(url, headers=self._auth_header, json=eventData)
         self._check_response(response)
         return (response.json()["eventsAdded"], response.json()["eventDetailId"])
 
-    def record_event(self, _type, details, times=[datetime.utcnow().isoformat()]):
+    def record_event(self, _type, details, times=None):
+        if times is None:
+            times = [datetime.now()]
         return self.record_event_data(
             {"description": {"type": _type, "details": details}}, times
         )

--- a/test/deviceapi.py
+++ b/test/deviceapi.py
@@ -1,4 +1,3 @@
-import json
 from urllib.parse import urljoin
 from datetime import datetime
 
@@ -21,24 +20,22 @@ class DeviceAPI(APIBase):
             props = {}
         return self._upload("/api/v1/audiorecordings", filename, props)
 
-    def record_event_data(self, eventData, times):
+    def record_event(self, type_, details, times=None):
+        data = {"description": {"type": type_, "details": details}}
+        return self.record_event_data(data, times)
+
+    def record_event_from_id(self, eventDetailId, times=None):
+        return self.record_event_data({"eventDetailId": eventDetailId}, times)
+
+    def record_event_data(self, eventData, times=None):
+        if times is None:
+            times = [datetime.now()]
         eventData["dateTimes"] = [t.isoformat() for t in times]
         url = urljoin(self._baseurl, "/api/v1/events")
+
         response = requests.post(url, headers=self._auth_header, json=eventData)
         self._check_response(response)
         return (response.json()["eventsAdded"], response.json()["eventDetailId"])
-
-    def record_event(self, _type, details, times=None):
-        if times is None:
-            times = [datetime.now()]
-        return self.record_event_data(
-            {"description": {"type": _type, "details": details}}, times
-        )
-
-    def record_event_from_id(
-        self, eventDetailId, times=[datetime.utcnow().isoformat()]
-    ):
-        return self.record_event_data({"eventDetailId": eventDetailId}, times)
 
     def get_audio_schedule(self):
         url = urljoin(self._baseurl, "/api/v1/schedules")

--- a/test/test_08_event.py
+++ b/test/test_08_event.py
@@ -7,10 +7,7 @@ class TestEvent:
         new_event_name = "E_" + helper.random_id()
 
         screech = doer.record_event(new_event_name, {"lure_id": "possum_screech"})
-
-        screech2 = doer.record_event(
-            new_event_name, {"lure_id": "possum_screech"}, "    and also"
-        )
+        screech2 = doer.record_event(new_event_name, {"lure_id": "possum_screech"})
 
         print(
             "Then these events with the same details should use the same eventDetailId."
@@ -19,9 +16,7 @@ class TestEvent:
             screech == screech2
         ), "And events with the same details should use the same eventDetailId"
 
-        howl = doer.record_event(
-            new_event_name, {"lure_id": "possum_howl"}, "Given this device also"
-        )
+        howl = doer.record_event(new_event_name, {"lure_id": "possum_howl"})
 
         print(
             "Then the events with some different details should have different eventDetailIds."
@@ -30,7 +25,7 @@ class TestEvent:
             screech != howl
         ), "Events with different details should link to different eventDetailIds"
 
-        no_lure_id = doer.record_event(new_event_name, "", "Given this device also")
+        no_lure_id = doer.record_event(new_event_name, "")
 
         print(
             "Then the event with no details should should have a different eventDetailId."

--- a/test/testdevice.py
+++ b/test/testdevice.py
@@ -91,11 +91,8 @@ class TestDevice:
 
     def record_three_events_at_once(self, detailId):
         print("    which has three events uploaded with detail id {}.".format(detailId))
-        times = [
-            datetime.utcnow().isoformat(),
-            (datetime.utcnow() - timedelta(seconds=2)).isoformat(),
-            (datetime.utcnow() - timedelta(seconds=4)).isoformat(),
-        ]
+        now = datetime.now()
+        times = [now, now - timedelta(seconds=2), now - timedelta(seconds=4)]
         eventsAdded, detailsId = self._deviceapi.record_event_from_id(detailId, times)
 
         print("Then three events should have been recorded.")

--- a/test/testdevice.py
+++ b/test/testdevice.py
@@ -78,14 +78,8 @@ class TestDevice:
     def _print_description(self, description):
         print(description, end="")
 
-    def record_event(self, _type, details, extraText="    which"):
-        self._print_description(
-            "{} has an event of type '{}' with details '{}'.".format(
-                extraText, _type, details
-            )
-        )
-        (count, detailsId) = self._deviceapi.record_event(_type, details)
-        print("  (EventDetails Id = {})".format(detailsId))
+    def record_event(self, type_, details, times=None):
+        count, detailsId = self._deviceapi.record_event(type_, details, times)
         assert count == 1
         return detailsId
 

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -192,14 +192,16 @@ class TestUser:
             self._group = self.create_group(self.username + "s_devices", False)
         return self._group
 
-    def can_see_events(self, device=None):
+    def can_see_events(self, device=None, startTime=None, endTime=None):
         deviceId = None
         if device is not None:
             deviceId = device.get_id()
-        return self._userapi.query_events(limit=10, deviceId=deviceId)
+        return self._userapi.query_events(
+            deviceId=deviceId, startTime=startTime, endTime=endTime
+        )
 
     def cannot_see_events(self):
-        events = self._userapi.query_events(limit=10)
+        events = self._userapi.query_events()
         assert not events, "User '{}' can see events when it shouldn't".format(
             self.username
         )

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -221,7 +221,7 @@ class TestUser:
         return self._userapi.download_file(file_id)
 
     def get_all_audio_baits(self):
-        return AudioBaitList(self._userapi.query_files('{"type":"audioBait"}'))
+        return AudioBaitList(self._userapi.query_files(where={"type": "audioBait"}))
 
     def delete_audio_bait_file(self, file_id):
         self._userapi.delete_file(file_id)

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -200,12 +200,9 @@ class TestUser:
 
     def cannot_see_events(self):
         events = self._userapi.query_events(limit=10)
-        if events:
-            raise TestException(
-                "User '{}' can see a events from '{}'".format(
-                    self.username, recordings[0]["DeviceId"]
-                )
-            )
+        assert not events, "User '{}' can see events when it shouldn't".format(
+            self.username
+        )
 
     def get_device_id(self, devicename):
         return self._userapi.get_device_id(devicename)

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -175,9 +175,13 @@ class UserAPI(APIBase):
         response = requests.post(url, headers=self._auth_header, data=tagData)
         response.raise_for_status()
 
-    def query_events(self, deviceId=None, startTime=None, endTime=None):
+    def query_events(self, deviceId=None, startTime=None, endTime=None, limit=20):
         return self._query(
-            "events", deviceId=deviceId, startTime=startTime, endTime=endTime, limit=20
+            "events",
+            deviceId=deviceId,
+            startTime=startTime,
+            endTime=endTime,
+            limit=limit,
         )
 
     def query_files(self, where=None, limit=None, offset=None):

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -4,6 +4,7 @@ import requests
 from collections import defaultdict
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 from urllib.parse import urljoin
+from datetime import datetime
 
 from .apibase import APIBase
 
@@ -177,11 +178,10 @@ class UserAPI(APIBase):
         response = requests.post(url, headers=self._auth_header, data=tagData)
         response.raise_for_status()
 
-    def query_events(self, deviceId=None, limit=None, offset=None):
-        where = {}
-        if deviceId is not None:
-            where["DeviceId"] = deviceId
-        return self._query("events", where=where, limit=limit, offset=offset)
+    def query_events(self, deviceId=None, startTime=None, endTime=None):
+        return self._query(
+            "events", deviceId=deviceId, startTime=startTime, endTime=endTime, limit=20
+        )
 
     def query_files(self, where=None, limit=None, offset=None):
         if where is None:
@@ -204,6 +204,8 @@ class UserAPI(APIBase):
             if value is not None:
                 if name == "where":
                     value = json.dumps(value)
+                elif isinstance(value, datetime):
+                    value = value.isoformat()
                 req_params[name] = value
 
         response = requests.get(url, params=req_params, headers=self._auth_header)

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -43,14 +43,19 @@ class UserAPI(APIBase):
             where["recordingDateTime"]["$gte"] = startDate.isoformat()
         if endDate is not None:
             where["recordingDateTime"]["$lte"] = endDate.isoformat()
-        params = {"where": json.dumps(where)}
 
-        if tagmode is not None:
-            params["tagMode"] = tagmode
         if tags is not None:
-            params["tags"] = json.dumps(tags)
+            tags = json.dumps(tags)
 
-        return self._query_results("recordings", params, limit, offset, filterOptions)
+        return self._query(
+            "recordings",
+            where=where,
+            limit=limit,
+            offset=offset,
+            tagMode=tagmode,
+            tags=tags,
+            filterOptions=filterOptions,
+        )
 
     def get_recording(self, recording_id, params=None):
         url = urljoin(self._baseurl, "/api/v1/recordings/{}".format(recording_id))
@@ -172,43 +177,44 @@ class UserAPI(APIBase):
         response = requests.post(url, headers=self._auth_header, data=tagData)
         response.raise_for_status()
 
-    def query_events(self, limit=None, offset=None, deviceId=None):
-        if deviceId is None:
-            where = "{}"
-        else:
-            where = '{"DeviceId":' + "{}".format(deviceId) + "}"
-        return self._query_results("events", {"where": where}, limit, offset)
+    def query_events(self, deviceId=None, limit=None, offset=None):
+        where = {}
+        if deviceId is not None:
+            where["DeviceId"] = deviceId
+        return self._query("events", where=where, limit=limit, offset=offset)
 
-    def query_files(self, where="{}", limit=None, offset=None):
-        return self._query_results("files", {"where": where}, limit, offset)
+    def query_files(self, where=None, limit=None, offset=None):
+        if where is None:
+            where = {}
+        return self._query("files", where=where, limit=limit, offset=offset)
 
     def _do_delete(self, deleteType, id):
         url = urljoin(self._baseurl, "/api/v1/{}/{}".format(deleteType, id))
         response = requests.delete(url, headers=self._auth_header)
         return self._check_response(response)
 
-    def _query_results(
-        self, queryname, params, limit=100, offset=0, filterOptions=None
-    ):
+    def _query(self, queryname, **params):
         url = urljoin(self._baseurl, "/api/v1/" + queryname)
 
-        if limit is not None:
-            params["limit"] = limit
-        if offset is not None:
-            params["offset"] = offset
-        if offset is not filterOptions:
-            params["filterOptions"] = filterOptions
+        params.setdefault("limit", 100)
+        params.setdefault("offset", 0)
 
-        response = requests.get(url, params=params, headers=self._auth_header)
+        req_params = {}
+        for name, value in params.items():
+            if value is not None:
+                if name == "where":
+                    value = json.dumps(value)
+                req_params[name] = value
+
+        response = requests.get(url, params=req_params, headers=self._auth_header)
         if response.status_code == 200:
             return response.json()["rows"]
-        elif response.status_code == 400:
-            messages = response.json()["messages"]
+        if response.status_code in (400, 422):
+            message = response.json()["message"]
             raise IOError(
-                "request failed ({}): {}".format(response.status_code, messages)
+                "request failed ({}): {}".format(response.status_code, message)
             )
-        else:
-            response.raise_for_status()
+        response.raise_for_status()
 
     def upload_file(self, filename, props):
         url = urljoin(self._baseurl, "api/v1/files")

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -45,9 +45,6 @@ class UserAPI(APIBase):
         if endDate is not None:
             where["recordingDateTime"]["$lte"] = endDate.isoformat()
 
-        if tags is not None:
-            tags = json.dumps(tags)
-
         return self._query(
             "recordings",
             where=where,
@@ -202,7 +199,7 @@ class UserAPI(APIBase):
         req_params = {}
         for name, value in params.items():
             if value is not None:
-                if name == "where":
+                if isinstance(value, (dict, list, tuple)):
                     value = json.dumps(value)
                 elif isinstance(value, datetime):
                     value = value.isoformat()


### PR DESCRIPTION
* Tighten up handling of get events query params
  - Automatic int conversion
  - Fixed bug when setting default for `limit`
  - Cleaner default handling
* Upgrade express-validator to address various sanitisation bugs
* Rationalise query test helpers
* Replace Events query "where" param with separate query params. This is safer and helps to avoid lock-in to sequelizejs.