### PR TITLE
Refactoring of recording retrieval

### DIFF
--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -79,7 +79,7 @@ async function get(request, type) {
   const recording = await models.Recording.get(
     request.user,
     request.params.id,
-    "canView",
+    models.Recording.Perms.VIEW,
     {
       type: type,
       filterOptions: request.query.filterOptions,
@@ -161,7 +161,7 @@ async function addTag(request, response) {
 
   if (request.user) {
     const permissions = await recording.getUserPermissions(request.user);
-    if (!permissions.canTag) {
+    if (!permissions.includes(models.Recording.Perms.TAG)) {
       responseUtil.send(response, {
         statusCode: 400,
         messages: ['User does not have permission to tag recording.']

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -76,11 +76,14 @@ function query(request, type) {
 }
 
 async function get(request, type) {
-  const recording = await models.Recording.getOne(
+  const recording = await models.Recording.get(
     request.user,
     request.params.id,
-    type,
-    request.query.filterOptions,
+    "canView",
+    {
+      type: type,
+      filterOptions: request.query.filterOptions,
+    }
   );
   if (!recording) {
     throw new ClientError("No file found with given datapoint.");


### PR DESCRIPTION
`Recording.getOne` is now `Recording.get` and now takes the required
permission to access the recording. This cleans up a bunch of call
sites, ensures that a permissions check is always done and simplifies
implementation of track based tagging (in progress).