### PR TITLE
Fix warnings related to pytest.raises

### DIFF
--- a/test/test_03_group.py
+++ b/test/test_03_group.py
@@ -47,7 +47,7 @@ class TestGroup:
         print(
             "Then Robert shouldn't be able to add himself to default group belonged to the admin"
         )
-        with pytest.raises(OSError, message=["Failed to add user to group."]):
+        with pytest.raises(OSError, match=r"Failed to add user to group."):
             robert.add_to_group(robert, helper.config.default_group)
 
     def test_user_cant_remove_person_from_group_unless_they_are_an_admin(self, helper):
@@ -58,7 +58,5 @@ class TestGroup:
         print(
             "Then Steve shouldn't be able to remove the admin from a group he is not an admin for"
         )
-        with pytest.raises(
-            OSError, message=["'Failed to remove user from the group.'"]
-        ):
+        with pytest.raises(OSError, match=r"Failed to remove user from the group."):
             steve.remove_from_group(helper.admin_user(), helper.config.default_group)

--- a/test/test_07_user_thermal.py
+++ b/test/test_07_user_thermal.py
@@ -52,14 +52,12 @@ class TestUserThermal:
         print("    and an unrelated user 'trouble'", end="")
         trouble = helper.given_new_user(self, "trouble")
 
-        print(
-            "Then 'trouble' should not be able to upload a recording on the behalf of the device."
-        )
-        with pytest.raises(
-            OSError,
-            message="On no 'trouble' could upload a recording on behalf of the device!",
-        ):
-            recording = trouble.uploads_recording_for(device)
+        print("Then 'trouble' should not be able to upload a recording on the behalf of the device.")
+        try:
+            trouble.uploads_recording_for(device)
+            pytest.fail("On no 'trouble' could upload a recording on behalf of the device!")
+        except OSError:
+            pass
 
     def test_cant_download_recording_via_audio_api(self, helper):
         device = helper.given_new_device(self, "user-thermal-download")

--- a/test/test_09_audio_bait.py
+++ b/test/test_09_audio_bait.py
@@ -54,10 +54,11 @@ class TestBait:
         james.delete_audio_bait_file(file1)
 
         print("But his friend Karl should not.")
-        with pytest.raises(
-            OSError, message="Karl should not have permissions to delete the file"
-        ):
+        try:
             helper.given_new_user(self, "karl").delete_audio_bait_file(file2)
+            pytest.fail("Karl should not have permissions to delete the file")
+        except OSError:
+            pass
 
         print("And the admin should also be able to delete a file")
         helper.admin_user().delete_audio_bait_file(file2)

--- a/test/test_10_schedule.py
+++ b/test/test_10_schedule.py
@@ -13,17 +13,11 @@ class TestSchedule:
         infilmator = helper.given_new_device(self, "in-film-ator")
 
         print("Then Louie cannot set the schedule this device.")
-        with pytest.raises(
-            OSError,
-            message="Louie should not have permissions to set schedule on this device.",
-        ):
+        with pytest.raises(OSError):
             louie.set_audio_schedule().for_device(infilmator)
 
         print("    or set schedules on both devices together.")
-        with pytest.raises(
-            OSError,
-            message="Louie should not have permissions to set schedule on this device.",
-        ):
+        with pytest.raises(OSError):
             louie.set_audio_schedule().for_devices(louies_device, infilmator)
 
         print("Administrators should be able to set the schedule on Louie's device.")
@@ -66,10 +60,7 @@ class TestSchedule:
         )
 
         print("Then Max should not be able to get audio schedule for the hollerer.")
-        with pytest.raises(
-            OSError,
-            message="Max should not have permissions to set schedule on this device.",
-        ):
+        with pytest.raises(OSError):
             print(max.get_audio_schedule(hollerer)["schedule"])
 
         print("But an admin user should be able to.")

--- a/test/test_11_global_permissions.py
+++ b/test/test_11_global_permissions.py
@@ -69,24 +69,15 @@ class TestGlobalPermission:
         fred.can_see_recordings(recording)
 
         print("  But not delete the recording")
-        with pytest.raises(
-            OSError,
-            message="Fred shoudl not be able to delete the recording with only global read permission",
-        ):
+        with pytest.raises(OSError):
             fred.delete_recording(recording)
 
         print("  Or update the recording")
-        with pytest.raises(
-            OSError,
-            message="Fred shoudl not be able to update the recording with only global read permission",
-        ):
+        with pytest.raises(OSError):
             fred.update_recording(recording, comment="testing")
 
         print("  Or tag the recording")
-        with pytest.raises(
-            OSError,
-            message="Fred shoudl not be able to tag the recording with only global read permission",
-        ):
+        with pytest.raises(OSError):
             fred.tag_recording(recording, {})
 
         print("When Fred is given global write permission")

--- a/test/test_13_device_users.py
+++ b/test/test_13_device_users.py
@@ -29,8 +29,11 @@ class TestDeviceUsers:
         jocelyn = helper.given_new_user(self, "Jocelyn")
 
         print("Then Jocelyn shouldn't be able to add herself to the device")
-        with pytest.raises(OSError, message=["Expected failed to add user to device."]):
+        try:
             jocelyn.add_to_device(jocelyn, shaper)
+            pytest.fail("User was able to add herself to device")
+        except OSError:
+            pass
 
     def test_user_cant_remove_person_from_device_unless_they_are_an_admin(self, helper):
         description = "If a new device 'Shaker' has an CPTV file"
@@ -43,10 +46,11 @@ class TestDeviceUsers:
         violet = helper.given_new_user(self, "Violet")
 
         print("Then Violet shouldn't be able to remove admin from the device")
-        with pytest.raises(
-            OSError, message=["Expected failed to remove user from device."]
-        ):
+        try:
             violet.remove_from_device(helper.admin_user(), shaker)
+            pytest.fail("User was able to remove admin from the device")
+        except OSError:
+            pass
 
     def test_can_list_device_users(self, helper):
         admin_user = helper.admin_user()


### PR DESCRIPTION
The `messages` argument to pytest.raises is now deprecated and
generates distracting warnings when pytest is run. There is no
replacement for that feature of pytest.raises.