### PR TITLE
Allow users with direct access to device to see recordings again

### DIFF
--- a/models/Recording.js
+++ b/models/Recording.js
@@ -319,7 +319,7 @@ module.exports = function(sequelize, DataTypes) {
 
   /* eslint-disable indent */
   Recording.prototype.getActiveTracksTagsAndTagger = async function() {
-    return await this.getTracks({ 
+    return await this.getTracks({
       where:{
         archivedAt:null
       },
@@ -338,7 +338,7 @@ module.exports = function(sequelize, DataTypes) {
    * //TODO This will be edited in the future when recordings can be public.
    */
   Recording.prototype.getUserPermissions = async function(user) {
-    if (user.hasGlobalWrite() || await user.isInGroup(this.GroupId)) {
+    if (user.hasGlobalWrite() || await user.isInGroup(this.GroupId) || await user.canAccessDevice(this.Device.id)) {
       return [
         Recording.Perms.DELETE,
         Recording.Perms.TAG,
@@ -431,7 +431,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   // reprocess a recording and set all active tracks to archived
-  Recording.prototype.reprocess = async function() {   
+  Recording.prototype.reprocess = async function() {
     models.Track.update(
       {archivedAt:Date.now()},
       {where: { RecordingId:this.id, archivedAt:null }}

--- a/models/User.js
+++ b/models/User.js
@@ -206,25 +206,26 @@ module.exports = function(sequelize, DataTypes) {
 
   // Returns the groups that are associated with this user (via
   // GroupUsers).
-  User.prototype.getGroupsIds = function() {
-    return this.getGroups()
-      .then(function(groups) {
-        return groups.map(g => g.id);
-      });
+  User.prototype.getGroupsIds = async function() {
+    const groups = await this.getGroups();
+    return groups.map(g => g.id);
   };
 
   User.prototype.isInGroup = async function(groupId) {
-    var groupIds = await this.getGroupsIds();
+    const groupIds = await this.getGroupsIds();
     return groupIds.includes(groupId);
   };
 
   // Returns the devices that are directly associated with this user
   // (via DeviceUsers).
-  User.prototype.getDeviceIds = function() {
-    return this.getDevices()
-      .then(function(devices) {
-        return devices.map(d => d.id);
-      });
+  User.prototype.getDeviceIds = async function() {
+    const devices = await this.getDevices();
+    return devices.map(d => d.id);
+  };
+
+  User.prototype.canAccessDevice = async function(deviceId) {
+    const deviceIds = await this.getDeviceIds();
+    return deviceIds.includes(deviceId);
   };
 
   User.prototype.checkUserControlsDevices = async function(deviceIds) {
@@ -240,9 +241,8 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   User.prototype.getAllDeviceIds = async function() {
-    var directDeviceIds = await this.getDeviceIds();
-    var groupedDeviceIds = await this.getGroupDeviceIds();
-
+    const directDeviceIds = await this.getDeviceIds();
+    const groupedDeviceIds = await this.getGroupDeviceIds();
     return directDeviceIds.concat(groupedDeviceIds);
   };
 

--- a/test/test_device_users.py
+++ b/test/test_device_users.py
@@ -3,22 +3,26 @@ import pytest
 
 class TestDeviceUsers:
     def test_can_assign_a_device_to_a_user_and_remove_them(self, helper):
+        admin_user = helper.admin_user()
+
         description = "If a new device 'Sharer' has an CPTV file"
         sharer = helper.given_new_device(self, "Sharer", description=description)
-        sharer.upload_recording()
+        recording = sharer.has_recording()
 
         print("   and a new user 'Sylvia' is added as a device user")
         sylvia = helper.given_new_user(self, "Sylvia")
-        helper.admin_user().add_to_device(sylvia, sharer)
+        admin_user.add_to_device(sylvia, sharer)
 
         print("Then Sylvia should see the recording from 'Sharer'")
         sylvia.can_see_recording_from(sharer)
+        sylvia.can_download_correct_recording(recording)
 
         print("When 'Sylvia' is removed from the device")
-        helper.admin_user().remove_from_device(sylvia, sharer)
+        admin_user.remove_from_device(sylvia, sharer)
 
         print("Then Sylvia should no longer see any recordings")
         sylvia.cannot_see_recordings()
+        sylvia.cannot_download_recording(recording)
 
     def test_user_cant_add_self_to_device(self, helper):
         description = "If a new device 'Shaper' has an CPTV file"

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -150,6 +150,10 @@ class TestUser:
         # Compare the remaining properties.
         assert recv_props == props
 
+    def cannot_download_recording(self, recording):
+        with pytest.raises(IOError):
+            self._userapi.get_recording(recording.id_)
+
     def delete_recording(self, recording):
         self._userapi.delete_recording(recording.id_)
 


### PR DESCRIPTION
Users with access through DeviceUsers could query recordings but not download them. This is a recently introduced regression.

Also added tests to cover this situation.