### PR TITLE
Deployment fixes

### DIFF
--- a/_release/build.sh
+++ b/_release/build.sh
@@ -34,10 +34,4 @@ perl -pi -e "s/^version:.+/version: \"${version}\"/" _release/nfpm.yaml
 json -I -f package.json -e "this.version=\"${version}\""
 json -I -f package-lock.json -e "this.version=\"${version}\""
 
-echo "Installing dependencies..."
-npm install
-
-echo "Creating API docs..."
-npm run apidoc
-
 nfpm -f _release/nfpm.yaml pkg -t ../cacophony-api_${version}.deb

--- a/_release/cacophony-api.service
+++ b/_release/cacophony-api.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 WorkingDirectory=/srv/cacophony/api
-ExecStart=/usr/local/bin/node Server.js --config=/etc/cacophony/api.js
+ExecStart=/usr/bin/node Server.js --config=/etc/cacophony/api.js
 Restart=on-failure
 RestartSec=20s
 User=fullnoise

--- a/_release/nfpm.yaml
+++ b/_release/nfpm.yaml
@@ -8,6 +8,10 @@ description: |
 vendor: "The Cacophony Project"
 homepage: https://github.com/TheCacophonyProject
 license: "GPLv3"
+depends:
+  - libpq-dev
+  - gyp
+
 files:
   "**/*": "/srv/cacophony/api/"
   "_release/cacophony-api.service": "/etc/systemd/system/cacophony-api.service"

--- a/_release/postinstall.sh
+++ b/_release/postinstall.sh
@@ -1,12 +1,42 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e -x
+section() {
+    echo ">>>> $1"
+}
 
-systemctl stop cacophony-api
+set -e
+
+section "Stopping API server"
+systemctl stop cacophony-api &> /dev/null
 
 cd /srv/cacophony/api
+
+if [[ ! -h config/app.js ]]; then
+    section "Moving configuration to /etc/cacophony"
+    mv config/app.js /etc/cacophony/api.js
+    ln -s /etc/cacophony/api.js config/app.js
+fi
+
+if [[ `stat -c '%U' node_modules` != "fullnoise" ]]; then
+    section "Removing outdated node_modules directory"
+    rm -rf node_modules
+    mkdir node_modules
+    chown fullnoise:fullnoise node_modules
+fi
+
+section "Installing dependencies"
+su fullnoise -s /bin/sh -c "npm install"
+
+section "Pruning unused dependencies"
+su fullnoise -s /bin/sh -c "npm prune"
+
+section "Running database migrations"
 npm run db-migrate
 
+section "Creating API docs"
+npm run apidoc
+
+section "Restarting API server"
 systemctl daemon-reload
 systemctl start cacophony-api
 systemctl status cacophony-api


### PR DESCRIPTION
For various reasons npm doesn't like you packaging up dependencies on
one host and copying them elsewhere. The .deb now installs and
rebuilds dependencies on the server.

Also:
- Fixed path to node binary
- have the .deb depend on libpq-dev so that the pq client library can
  be built
- Move the previous config file to new location and symlink to
it (needed for DB migrations to work)
- Unused npm dependeices are pruned on every upgrade
- API docs are now re-built on the server instead of being included in
  the package.