### PR TITLE
Fixed call from middleware.js to customErrors.js

### DIFF
--- a/api/middleware.js
+++ b/api/middleware.js
@@ -264,7 +264,7 @@ function ifUsersDeviceRequestWrapper(fn) {
     }
 
     if (!("user" in request)) {
-      throw new customErrors("No user specified.", 422);
+      throw new customErrors.ClientError("No user specified.", 422);
     }
 
     try {


### PR DESCRIPTION
In lines 266 to 268 middleware.js has
if (!("user" in request)) { throw new customErrors("No user specified.", 422); }

The call should be to the function ClientError in the module customErrors
if (!("user" in request)) { throw new customErrors.ClientError("No user specified.", 422); }