### PR TITLE
Fixes #128. Refactored auth handling to use standard Express middleware and return 401/403

### DIFF
--- a/api/V1/Admin.js
+++ b/api/V1/Admin.js
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 const middleware   = require('../middleware');
+const auth         = require('../auth');
 const models       = require('../../models');
 const responseUtil = require('./responseUtil');
 const { param, body } = require('express-validator/check');
@@ -37,24 +38,18 @@ module.exports = function(app, baseUrl) {
   app.patch(
     apiUrl+'/global_permission/:username',
     [
-      middleware.authenticateAdmin,
+      auth.authenticateAdmin,
       middleware.getUserByName(param),
       body('permission').isIn(models.User.GLOBAL_PERMISSIONS),
     ],
     middleware.requestWrapper(async (request, response) => {
-      const updated = await models.User.changeGlobalPermission(
-        request.admin, request.body.user, request.body.permission);
-      if (updated) {
-        responseUtil.send(response, {
-          statusCode: 200,
-          messages: ['Users global permission updated.'],
-        });
-      } else {
-        responseUtil.send(response, {
-          statusCode: 400,
-          messages: ['Failed to update users global permission.'],
-        });
-      }
+      await models.User.changeGlobalPermission(
+        request.admin, request.body.user, request.body.permission
+      );
+      responseUtil.send(response, {
+        statusCode: 200,
+        messages: ['Users global permission updated.'],
+      });
     })
   );
 };

--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -21,6 +21,7 @@ const moment = require('moment');
 const { format } = require('util');
 
 const middleware = require('../middleware');
+const auth       = require('../auth');
 const models = require('../../models');
 const recordingUtil = require('./recordingUtil');
 const responseUtil = require('./responseUtil');
@@ -68,7 +69,7 @@ module.exports = function(app, baseUrl) {
   app.post(
     apiUrl,
     [
-      middleware.authenticateDevice,
+      auth.authenticateDevice,
     ],
     middleware.requestWrapper(
       recordingUtil.makeUploadHandler(mungeAudioData)
@@ -95,7 +96,7 @@ module.exports = function(app, baseUrl) {
   app.put(
     apiUrl + "/:id",
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt(),
       middleware.parseJSON('data', body),
     ],
@@ -125,7 +126,7 @@ module.exports = function(app, baseUrl) {
   app.delete(
     apiUrl + '/:id',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -156,7 +157,7 @@ module.exports = function(app, baseUrl) {
   app.get(
     apiUrl,
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.parseJSON('where', header).optional(),
       header('offset').isInt().optional(),
       header('limit').isInt().optional(),
@@ -224,7 +225,7 @@ module.exports = function(app, baseUrl) {
   app.get(
     apiUrl + "/:id",
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -21,6 +21,7 @@ const jwt          = require('jsonwebtoken');
 const config       = require('../../config');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
+const auth         = require('../auth');
 const { query, body }     = require('express-validator/check');
 
 module.exports = function(app, baseUrl) {
@@ -76,7 +77,7 @@ module.exports = function(app, baseUrl) {
    */
   app.get(
     apiUrl,
-    [ middleware.authenticateUser ],
+    [ auth.authenticateUser ],
     middleware.requestWrapper(async (request, response) => {
       var devices = await models.Device.allForUser(request.user);
       return responseUtil.send(response, {
@@ -107,7 +108,7 @@ module.exports = function(app, baseUrl) {
   app.get(
     apiUrl + '/users',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.getDeviceById(query),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -159,7 +160,7 @@ module.exports = function(app, baseUrl) {
   app.post(
     apiUrl + '/users',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.getUserByNameOrId(body),
       middleware.getDeviceById(body),
       body('admin').isIn([true, false]),
@@ -205,7 +206,7 @@ module.exports = function(app, baseUrl) {
   app.delete(
     apiUrl + '/users',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.getDeviceById(body),
       middleware.getUserByNameOrId(body),
     ],

--- a/api/V1/Event.js
+++ b/api/V1/Event.js
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const models       = require('../../models');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
+const auth         = require('../auth');
 const { body, query, oneOf } = require('express-validator/check');
 
 
@@ -52,7 +53,7 @@ module.exports = function(app, baseUrl) {
   app.post(
     apiUrl,
     [
-      middleware.authenticateDevice,
+      auth.authenticateDevice,
       middleware.getDetailSnapshotById(body, 'eventDetailId').optional(),
       middleware.isDateArray("dateTimes", "List of times event occured is required."),
       oneOf([
@@ -117,7 +118,7 @@ module.exports = function(app, baseUrl) {
   app.get(
     apiUrl,
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       query('startTime').isISO8601({ strict: true }).optional(),
       query('endTime').isISO8601({ strict: true }).optional(),
       query('deviceId').isInt().optional().toInt(),

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const { query, param, body } = require('express-validator/check');
 
 const middleware        = require('../middleware');
+const auth              = require('../auth');
 const models            = require('../../models');
 const recordingUtil     = require('./recordingUtil');
 const responseUtil      = require('./responseUtil');
@@ -65,7 +66,7 @@ module.exports = (app, baseUrl) => {
   app.post(
     apiUrl,
     [
-      middleware.authenticateDevice,
+      auth.authenticateDevice,
     ],
     middleware.requestWrapper(
       recordingUtil.makeUploadHandler()
@@ -92,10 +93,11 @@ module.exports = (app, baseUrl) => {
   app.post(
     apiUrl + "/:devicename",
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.getDeviceByName(param),
+      auth.userCanAccessDevices,
     ],
-    middleware.ifUsersDeviceRequestWrapper(
+    middleware.requestWrapper(
       recordingUtil.makeUploadHandler()
     )
   );
@@ -128,7 +130,7 @@ module.exports = (app, baseUrl) => {
   app.get(
     apiUrl,
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.parseJSON('where', query).optional(),
       query('offset').isInt().optional(),
       query('limit').isInt().optional(),
@@ -173,7 +175,7 @@ module.exports = (app, baseUrl) => {
   app.get(
     apiUrl + '/:id',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt(),
       middleware.parseJSON('filterOptions', query).optional(),
     ],
@@ -202,7 +204,7 @@ module.exports = (app, baseUrl) => {
   app.delete(
     apiUrl + '/:id',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -235,7 +237,7 @@ module.exports = (app, baseUrl) => {
   app.patch(
     apiUrl + '/:id',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt(),
       middleware.parseJSON('updates', body),
     ],
@@ -277,7 +279,7 @@ module.exports = (app, baseUrl) => {
   app.post(
     apiUrl + '/:id/tracks',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt().toInt(),
       middleware.parseJSON('data', body),
       middleware.parseJSON('algorithm', body).optional(),
@@ -291,7 +293,7 @@ module.exports = (app, baseUrl) => {
       if (!recording) {
         responseUtil.send(response, {
           statusCode: 400,
-          messages: ["No such recording or access denied."],
+          messages: ["No such recording."],
         });
         return;
       }
@@ -328,7 +330,7 @@ module.exports = (app, baseUrl) => {
   app.get(
     apiUrl + '/:id/tracks',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -340,7 +342,7 @@ module.exports = (app, baseUrl) => {
       if (!recording) {
         responseUtil.send(response, {
           statusCode: 400,
-          messages: ["No such recording or access denied."],
+          messages: ["No such recording."],
         });
         return;
       }
@@ -370,7 +372,7 @@ module.exports = (app, baseUrl) => {
   app.delete(
     apiUrl + '/:id/tracks/:trackId',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt().toInt(),
       param('trackId').isInt().toInt(),
     ],
@@ -408,7 +410,7 @@ module.exports = (app, baseUrl) => {
   app.post(
     apiUrl + '/:id/tracks/:trackId/tags',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt().toInt(),
       param('trackId').isInt().toInt(),
       body('what'),
@@ -450,7 +452,7 @@ module.exports = (app, baseUrl) => {
   app.delete(
     apiUrl + '/:id/tracks/:trackId/tags/:trackTagId',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt().toInt(),
       param('trackId').isInt().toInt(),
       param('trackTagId').isInt().toInt(),
@@ -494,7 +496,7 @@ module.exports = (app, baseUrl) => {
   app.get(
     apiUrl + '/reprocess/:id',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       param('id').isInt(),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -517,7 +519,7 @@ module.exports = (app, baseUrl) => {
   app.post(
     apiUrl + '/reprocess/multiple',
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.parseJSON('recordings', body),
 
     ],
@@ -536,7 +538,7 @@ module.exports = (app, baseUrl) => {
     if (!recording) {
       responseUtil.send(response, {
         statusCode: 400,
-        messages: ["No such recording or access denied."],
+        messages: ["No such recording."],
       });
       return;
     }

--- a/api/V1/Schedule.js
+++ b/api/V1/Schedule.js
@@ -20,6 +20,7 @@ const { body, param } = require('express-validator/check');
 const models = require('../../models');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
+const auth         = require('../auth');
 
 module.exports = (app, baseUrl) => {
   var apiUrl = baseUrl + '/schedules';
@@ -43,11 +44,12 @@ module.exports = (app, baseUrl) => {
   app.post(
     apiUrl,
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.parseArray('devices', body),
       middleware.parseJSON('schedule', body),
+      auth.userCanAccessDevices,
     ],
-    middleware.ifUsersDeviceRequestWrapper(async function(request, response) {
+    middleware.requestWrapper(async function(request, response) {
       var deviceIds = request.body.devices;
 
       var instance = models.Schedule.build(request.body, ["schedule"]);
@@ -83,7 +85,7 @@ module.exports = (app, baseUrl) => {
   app.get(
     apiUrl,
     [
-      middleware.authenticateDevice,
+      auth.authenticateDevice,
     ],
     middleware.requestWrapper(async (request, response) => {
       return getSchedule(request.device, response);
@@ -106,10 +108,11 @@ module.exports = (app, baseUrl) => {
   app.get(
     apiUrl + "/:devicename",
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.getDeviceByName(param),
+      auth.userCanAccessDevices,
     ],
-    middleware.ifUsersDeviceRequestWrapper(async (request, response) => {
+    middleware.requestWrapper(async (request, response) => {
       getSchedule(request.device, response, request.user);
     })
   );

--- a/api/V1/Tag.js
+++ b/api/V1/Tag.js
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const { body } = require('express-validator/check');
 
 const middleware = require('../middleware');
+const auth       = require('../auth');
 const models = require('../../models');
 const recordingUtil = require('./recordingUtil');
 const responseUtil = require('./responseUtil');
@@ -62,7 +63,7 @@ module.exports = function(app, baseUrl) {
   app.post(
     apiUrl,
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.parseJSON('tag', body),
       body('recordingId').isInt(),
     ],
@@ -75,7 +76,7 @@ module.exports = function(app, baseUrl) {
   app.delete(
     apiUrl,
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       body('tagId').isInt(),
     ],
     middleware.requestWrapper(async function(request, response) {

--- a/api/V1/User.js
+++ b/api/V1/User.js
@@ -21,6 +21,7 @@ const jwt          = require('jsonwebtoken');
 const config       = require('../../config');
 const responseUtil = require('./responseUtil');
 const middleware   = require('../middleware');
+const auth         = require('../auth');
 const { body, param } = require('express-validator/check');
 const { ClientError } = require('../customErrors');
 
@@ -86,7 +87,7 @@ module.exports = function(app, baseUrl) {
   app.patch(
     apiUrl,
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.parseJSON('data', body),
     ],
     middleware.requestWrapper(async (request, response) => {
@@ -122,7 +123,7 @@ module.exports = function(app, baseUrl) {
   app.get(
     apiUrl + "/:username",
     [
-      middleware.authenticateUser,
+      auth.authenticateUser,
       middleware.getUserByName(param),
     ],
     middleware.requestWrapper(async (request, response) => {

--- a/api/V1/signedUrl.js
+++ b/api/V1/signedUrl.js
@@ -21,6 +21,7 @@ const stream          = require('stream');
 const config          = require('../../config');
 const log             = require('../../logging');
 const middleware      = require('../middleware');
+const auth            = require('../auth');
 const modelsUtil      = require('../../models/util/util');
 const responseUtil    = require('./responseUtil');
 const { ClientError } = require('../customErrors');
@@ -45,7 +46,7 @@ module.exports = function(app, baseUrl) {
   app.get(
     baseUrl + '/signedUrl',
     [
-      middleware.signedUrl,
+      auth.signedUrl,
     ],
     middleware.requestWrapper(async (request, response) => {
 

--- a/api/auth.js
+++ b/api/auth.js
@@ -1,0 +1,143 @@
+/*
+cacophony-api: The Cacophony Project API server
+Copyright (C) 2018  The Cacophony Project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+const config       = require('../config');
+const jwt          = require('jsonwebtoken');
+const ExtractJwt   = require('passport-jwt').ExtractJwt;
+const customErrors = require('./customErrors');
+const format       = require('util').format;
+const models = require('../models');
+
+const getVerifiedJWT = (req) => {
+  const token = ExtractJwt.fromAuthHeaderWithScheme('jwt')(req);
+  if (!token) {
+    throw new customErrors.AuthenticationError('Could not find JWT token.');
+  }
+  try {
+    return jwt.verify(token, config.server.passportSecret);
+  } catch(e) {
+    throw new customErrors.AuthenticationError('Failed to verify JWT.');
+  }
+};
+
+/*
+ * Authenticate a JWT in the 'Authorization' header of the given type
+ */
+const authenticate = function(type) {
+  return async (req, res, next) => {
+    let jwtDecoded;
+    try {
+      jwtDecoded = getVerifiedJWT(req);
+    } catch(e) {
+      return res.status(401).json({"messages": [e.message]});
+    }
+    if (type && type != jwtDecoded._type) {
+      return res.status(401).json({"messages": [format('Invalid type of JWT. Need one of %s for this request, but had %s.', type, jwtDecoded._type)]});
+    }
+    let result;
+    switch(jwtDecoded._type) {
+      case 'user':
+        result = await models.User.findByPk(jwtDecoded.id);
+        break;
+      case 'device':
+        result = await models.Device.findByPk(jwtDecoded.id);
+        break;
+      case 'fileDownload':
+        result = jwtDecoded;
+        break;
+    }
+    if (result == null) {
+      return res.status(401).json({"messages": [format('Could not find a %s from the JWT.', type)]});
+    }
+    req[type] = result;
+    next();
+  };
+};
+
+const authenticateUser   = authenticate('user');
+const authenticateDevice = authenticate('device');
+const authenticateAny    = authenticate(null);
+
+const authenticateAdmin = async (req, res, next) => {
+  let jwtDecoded;
+  try {
+    jwtDecoded = getVerifiedJWT(req);
+  } catch(e) {
+    res.status(401).send(e.message);
+  }
+  if (jwtDecoded._type != 'user') {
+    return res.status(403).json({"messages": ['Admin has to be a user']});
+  }
+  const user = await models.User.findByPk(jwtDecoded.id);
+  if (!user) {
+    return res.status(401).json({"messages": ['Could not find user from JWT.']});
+  }
+  if (!user.hasGlobalWrite()) {
+    return res.status(403).json({"messages": ['User is not an admin.']});
+  }
+  req.admin = user;
+  next();
+};
+
+const signedUrl = (req, res, next) => {
+  const jwtParam = req.query["jwt"];
+  if (jwtParam == null) {
+    return res.status(401).json({"messages": ['Could not find JWT token in query params.']});
+  }
+  let jwtDecoded;
+  try {
+    jwtDecoded = jwt.verify(jwtParam, config.server.passportSecret);
+  } catch(e) {
+    return res.status(401).json({"messages": ['Failed to verify JWT.']});
+  }
+  req.jwtDecoded = jwtDecoded;
+  next();
+};
+
+// A request wrapper that also checks if user should be playing around with the
+// the named device before continuing.
+const userCanAccessDevices = async (request, response, next) => {
+  let devices = [];
+  if ("device" in request.body && request.body.device) {
+    request["device"] = request.body.device;
+    devices = [request.body.device.id];
+  }
+  else if ("devices" in request.body) {
+    devices = request.body.devices;
+  } else {
+    throw new customErrors.ClientError("No devices specified.", 422);
+  }
+
+  if (!("user" in request)) {
+    throw new customErrors.ClientError("No user specified.", 422);
+  }
+
+  try {
+    await request.user.checkUserControlsDevices(devices);
+  } catch(e) {
+    return response.status(403).json({"messages": [e.message]});
+  }
+  next();
+};
+
+exports.authenticateUser   = authenticateUser;
+exports.authenticateDevice = authenticateDevice;
+exports.authenticateAny    = authenticateAny;
+exports.authenticateAdmin  = authenticateAdmin;
+exports.signedUrl          = signedUrl;
+exports.userCanAccessDevices = userCanAccessDevices;

--- a/api/auth.js
+++ b/api/auth.js
@@ -51,15 +51,15 @@ const authenticate = function(type) {
     }
     let result;
     switch(jwtDecoded._type) {
-      case 'user':
-        result = await models.User.findByPk(jwtDecoded.id);
-        break;
-      case 'device':
-        result = await models.Device.findByPk(jwtDecoded.id);
-        break;
-      case 'fileDownload':
-        result = jwtDecoded;
-        break;
+    case 'user':
+      result = await models.User.findByPk(jwtDecoded.id);
+      break;
+    case 'device':
+      result = await models.Device.findByPk(jwtDecoded.id);
+      break;
+    case 'fileDownload':
+      result = jwtDecoded;
+      break;
     }
     if (result == null) {
       return res.status(401).json({"messages": [format('Could not find a %s from the JWT.', type)]});

--- a/api/customErrors.js
+++ b/api/customErrors.js
@@ -35,7 +35,7 @@ function errorHandler(err, request, response, next) { // eslint-disable-line
 function CustomError() {
   this.statusCode = 500;
 }
-CustomError.prototype = new Error();
+CustomError.prototype = new Error;
 
 function ValidationError(errors) {
   this.name = "Validation";
@@ -63,8 +63,44 @@ function ValidationError(errors) {
     };
   };
 }
-ValidationError.prototype = new CustomError();
+ValidationError.prototype = new CustomError;
 ValidationError.prototype.constructor = ClientError;
+
+function AuthenticationError(message) {
+  this.name = "Authentication";
+  this.message = message;
+  this.statusCode = 401;
+  this.toString = () => {
+    return format("%s error[%d]: %s.", this.name, this.statusCode, this.message);
+  };
+  this.toJson = () => {
+    return {
+      message: this.message,
+      errorType: this.name.toLowerCase(),
+    };
+  };
+}
+
+AuthenticationError.prototype = new CustomError;
+AuthenticationError.prototype.constructor = AuthenticationError;
+
+function AuthorizationError(message) {
+  this.name = "AuthorizationError";
+  this.message = message;
+  this.statusCode = 403;
+  this.toString = () => {
+    return format("%s error[%d]: %s.", this.name, this.statusCode, this.message);
+  };
+  this.toJson = () => {
+    return {
+      message: this.message,
+      errorType: this.name.toLowerCase(),
+    };
+  };
+}
+
+AuthorizationError.prototype = new CustomError;
+AuthorizationError.prototype.constructor = AuthorizationError;
 
 function ClientError(message, statusCode) {
   if (statusCode == undefined) {
@@ -83,9 +119,11 @@ function ClientError(message, statusCode) {
     };
   };
 }
-ClientError.prototype = new CustomError();
+ClientError.prototype = new CustomError;
 ClientError.prototype.constructor = ClientError;
 
 exports.ValidationError = ValidationError;
+exports.AuthenticationError = AuthenticationError;
+exports.AuthorizationError = AuthorizationError;
 exports.ClientError     = ClientError;
 exports.errorHandler    = errorHandler;

--- a/models/Device.js
+++ b/models/Device.js
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 var bcrypt = require('bcrypt');
 var Sequelize = require('sequelize');
+const {AuthorizationError} = require("../api/customErrors");
 const Op = Sequelize.Op;
 
 module.exports = function(sequelize, DataTypes) {
@@ -82,7 +83,7 @@ module.exports = function(sequelize, DataTypes) {
       return false;
     }
     if (!(await device.userPermissions(authUser)).canAddUsers) {
-      return false;
+      throw new AuthorizationError("User is not a group, device, or global admin so cannot add users to this device");
     }
 
     // Get association if already there and update it.
@@ -111,7 +112,7 @@ module.exports = function(sequelize, DataTypes) {
       return false;
     }
     if (!(await device.userPermissions(authUser)).canRemoveUsers) {
-      return false;
+      throw new AuthorizationError("User is not a group, device, or global admin so cannot remove users from this device");
     }
 
     // Check that association is there to delete.

--- a/models/File.js
+++ b/models/File.js
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 'use strict';
+const {AuthorizationError} = require("../api/customErrors");
 module.exports = function(sequelize, DataTypes) {
   var name = 'File';
 
@@ -63,14 +64,11 @@ module.exports = function(sequelize, DataTypes) {
     return this.findAndCountAll(q);
   };
 
-  File.deleteIfAllowed = async function(user, file) {
-    if (user.hasGlobalWrite() || user.id == file.UserId) {
-      await file.destroy();
-      return true;
+  File.deleteIfAllowedElseThrow = async function(user, file) {
+    if (!user.hasGlobalWrite() && user.id != file.UserId) {
+      throw new AuthorizationError("The user does not own that file and is not a global admin!");
     }
-    else {
-      return false;
-    }
+    await file.destroy();
   };
 
   return File;

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -25,6 +25,7 @@ const uuidv4 = require('uuid/v4');
 
 var util = require('./util/util');
 var validation = require('./util/validation');
+const { AuthorizationError } = require("../api/customErrors");
 
 
 module.exports = function(sequelize, DataTypes) {
@@ -299,7 +300,6 @@ module.exports = function(sequelize, DataTypes) {
       where: {
         [Op.and]: [
           { id: id },
-          await recordingsFor(user),
         ],
       },
       include: [
@@ -319,7 +319,7 @@ module.exports = function(sequelize, DataTypes) {
     }
     const userPermissions = await recording.getUserPermissions(user);
     if (!userPermissions.includes(permission)) {
-      return null;
+      throw new AuthorizationError("The user does not have permission to view this file");
     }
 
     recording.filterData(makeFilterOptions(user, options.filterOptions));

--- a/test/apibase.py
+++ b/test/apibase.py
@@ -26,7 +26,8 @@ class APIBase:
             self._set_jwt_token(response)
             return
         if response.status_code == 422:
-            raise ValueError("Could not log on as '{}'.  Please check {} name.".format(self._loginname, self._logintype))
+            raise ValueError("Could not log on as '{}'.  Please check {} name."
+                             .format(self._loginname, self._logintype))
         raise_specific_exception(response)
 
     def register_as_new(self, group=None, email=None):

--- a/test/deviceapi.py
+++ b/test/deviceapi.py
@@ -35,7 +35,7 @@ class DeviceAPI(APIBase):
 
         response = requests.post(url, headers=self._auth_header, json=eventData)
         self._check_response(response)
-        return (response.json()["eventsAdded"], response.json()["eventDetailId"])
+        return response.json()["eventsAdded"], response.json()["eventDetailId"]
 
     def get_audio_schedule(self):
         url = urljoin(self._baseurl, "/api/v1/schedules")

--- a/test/fileprocessingapi.py
+++ b/test/fileprocessingapi.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 
 import requests
 
+from .testexception import raise_specific_exception
 from .recording import Recording
 
 
@@ -18,8 +19,7 @@ class FileProcessingAPI:
             data = r.json()["recording"]
             id_ = data.pop("id")
             return Recording(id_, data, None)
-
-        raise IOError(r.text)
+        raise_specific_exception(r)
 
     def put(self, recording, success, complete, updates=None, new_object_key=None):
         post_data = {
@@ -36,7 +36,7 @@ class FileProcessingAPI:
         r = requests.put(self._url, data=post_data)
         if r.status_code == 200:
             return
-        raise IOError(r.text)
+        raise_specific_exception(r)
 
     def get_algorithm_id(self, algorithm):
         url = self._url + "/algorithm"
@@ -44,7 +44,7 @@ class FileProcessingAPI:
         r = requests.post(url, data=post_data)
         if r.status_code == 200:
             return r.json()["algorithmId"]
-        raise IOError(r.text)
+        raise_specific_exception(r)
 
     def add_track(self, recording, track, algorithm={"tracking-format": 42}):
         algorithm_id = self.get_algorithm_id(algorithm)
@@ -53,11 +53,11 @@ class FileProcessingAPI:
         r = requests.post(url, data=post_data)
         if r.status_code == 200:
             return r.json()["trackId"]
-        raise IOError(r.text)
+        raise_specific_exception(r)
 
     def clear_tracks(self, recording):
         r = requests.delete(self._url + "/{}/tracks".format(recording.id_))
-        r.raise_for_status()
+        raise_specific_exception(r)
 
     def add_track_tag(self, track, tag):
         url = self._url + "/{}/tracks/{}/tags".format(track.recording.id_, track.id_)
@@ -69,4 +69,4 @@ class FileProcessingAPI:
         r = requests.post(url, data=post_data)
         if r.status_code == 200:
             return r.json()["trackTagId"]
-        raise IOError(r.text)
+        raise_specific_exception(r)

--- a/test/helper.py
+++ b/test/helper.py
@@ -7,7 +7,7 @@ from .deviceapi import DeviceAPI
 from .testuser import TestUser
 from .testdevice import TestDevice
 from .testconfig import TestConfig
-from .testexception import TestException
+from .testexception import TestException, UnprocessableError
 
 
 class Helper:
@@ -66,8 +66,8 @@ class Helper:
                 ).register_as_new()
                 self._print_actual_name(testname)
                 return TestUser(testname, api, testemail)
-            except OSError:
-                pass
+            except UnprocessableError:
+                pass  # expected
             testname = "{}{}".format(basename, num)
             testemail = "{}{}".format(num, baseemail)
 

--- a/test/test_audio_bait.py
+++ b/test/test_audio_bait.py
@@ -1,5 +1,7 @@
 import pytest
 
+from test.testexception import AuthorizationError
+
 
 class TestBait:
     def test_anyone_or_device_can_download_audio_bait(self, helper):
@@ -54,11 +56,8 @@ class TestBait:
         james.delete_audio_bait_file(file1)
 
         print("But his friend Karl should not.")
-        try:
+        with pytest.raises(AuthorizationError):
             helper.given_new_user(self, "karl").delete_audio_bait_file(file2)
-            pytest.fail("Karl should not have permissions to delete the file")
-        except OSError:
-            pass
 
         print("And the admin should also be able to delete a file")
         helper.admin_user().delete_audio_bait_file(file2)

--- a/test/test_device_users.py
+++ b/test/test_device_users.py
@@ -1,5 +1,7 @@
 import pytest
 
+from test.testexception import AuthorizationError
+
 
 class TestDeviceUsers:
     def test_can_assign_a_device_to_a_user_and_remove_them(self, helper):
@@ -33,11 +35,8 @@ class TestDeviceUsers:
         jocelyn = helper.given_new_user(self, "Jocelyn")
 
         print("Then Jocelyn shouldn't be able to add herself to the device")
-        try:
+        with pytest.raises(AuthorizationError):
             jocelyn.add_to_device(jocelyn, shaper)
-            pytest.fail("User was able to add herself to device")
-        except OSError:
-            pass
 
     def test_user_cant_remove_person_from_device_unless_they_are_an_admin(self, helper):
         description = "If a new device 'Shaker' has an CPTV file"
@@ -50,11 +49,8 @@ class TestDeviceUsers:
         violet = helper.given_new_user(self, "Violet")
 
         print("Then Violet shouldn't be able to remove admin from the device")
-        try:
+        with pytest.raises(AuthorizationError):
             violet.remove_from_device(helper.admin_user(), shaker)
-            pytest.fail("User was able to remove admin from the device")
-        except OSError:
-            pass
 
     def test_can_list_device_users(self, helper):
         admin_user = helper.admin_user()

--- a/test/test_global_permissions.py
+++ b/test/test_global_permissions.py
@@ -1,5 +1,7 @@
 import pytest
 
+from test.testexception import AuthorizationError
+
 
 class TestGlobalPermission:
     def test_setting_global_permissions(self, helper):
@@ -8,23 +10,23 @@ class TestGlobalPermission:
         bob = helper.given_new_user(self, "bob")
 
         print("  Tom shoud not be able to change global permissions for himself")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             tom.set_global_permission(tom.username, "write")
 
         print("  Or other users (bob)")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             tom.set_global_permission(bob.username, "write")
 
         print("When Tom is given global read permission")
         admin = helper.admin_user()
         admin.set_global_permission(tom.username, "read")
 
-        print(" he shoud still not be able to change global permissions for himself")
-        with pytest.raises(OSError):
+        print(" he should still not be able to change global permissions for himself")
+        with pytest.raises(AuthorizationError):
             tom.set_global_permission(tom.username, "write")
 
         print("  Or other users (bob)")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             tom.set_global_permission(bob.username, "write")
 
         print("When Tom is given global write permission")
@@ -69,15 +71,15 @@ class TestGlobalPermission:
         fred.can_see_recordings(recording)
 
         print("  But not delete the recording")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             fred.delete_recording(recording)
 
         print("  Or update the recording")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             fred.update_recording(recording, comment="testing")
 
         print("  Or tag the recording")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             fred.tag_recording(recording, {})
 
         print("When Fred is given global write permission")

--- a/test/test_group.py
+++ b/test/test_group.py
@@ -1,5 +1,7 @@
 import pytest
 
+from test.testexception import AuthorizationError
+
 
 class TestGroup:
     def test_group_can_be_created_and_users_added_to_it_and_removed_from_it(
@@ -44,10 +46,8 @@ class TestGroup:
         print("Given a Robert is a new user", end="")
         robert = helper.given_new_user(self, "robert")
 
-        print(
-            "Then Robert shouldn't be able to add himself to default group belonged to the admin"
-        )
-        with pytest.raises(OSError, match=r"Failed to add user to group."):
+        print("Then Robert shouldn't be able to add himself to default group belonged to the admin")
+        with pytest.raises(AuthorizationError):
             robert.add_to_group(robert, helper.config.default_group)
 
     def test_user_cant_remove_person_from_group_unless_they_are_an_admin(self, helper):
@@ -55,8 +55,6 @@ class TestGroup:
         print("Given a Steve is a new user", end="")
         steve = helper.given_new_user(self, "steve")
 
-        print(
-            "Then Steve shouldn't be able to remove the admin from a group he is not an admin for"
-        )
-        with pytest.raises(OSError, match=r"Failed to remove user from the group."):
+        print("Then Steve shouldn't be able to remove the admin from a group he is not an admin for")
+        with pytest.raises(AuthorizationError):
             steve.remove_from_group(helper.admin_user(), helper.config.default_group)

--- a/test/test_schedule.py
+++ b/test/test_schedule.py
@@ -2,6 +2,8 @@ import pytest
 import time
 import json
 
+from test.testexception import AuthorizationError
+
 
 class TestSchedule:
     def test_only_device_owners_can_set_schedule(self, helper):
@@ -13,11 +15,11 @@ class TestSchedule:
         infilmator = helper.given_new_device(self, "in-film-ator")
 
         print("Then Louie cannot set the schedule this device.")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             louie.set_audio_schedule().for_device(infilmator)
 
         print("    or set schedules on both devices together.")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             louie.set_audio_schedule().for_devices(louies_device, infilmator)
 
         print("Administrators should be able to set the schedule on Louie's device.")
@@ -60,7 +62,7 @@ class TestSchedule:
         )
 
         print("Then Max should not be able to get audio schedule for the hollerer.")
-        with pytest.raises(OSError):
+        with pytest.raises(AuthorizationError):
             print(max.get_audio_schedule(hollerer)["schedule"])
 
         print("But an admin user should be able to.")

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -1,6 +1,8 @@
 import json
 import pytest
 
+from .testexception import UnprocessableError
+
 
 class TestUser:
     def test_can_create_new_user(self, helper):
@@ -37,18 +39,16 @@ class TestUser:
         try:
             print("If a user DuplicateBob signs up")
             helper.given_new_fixed_user("DuplicateBob")
-        except OSError:
+        except UnprocessableError:
             pass  # expected
 
         # Now try to create the same user again
-        with pytest.raises(OSError) as excinfo:
+        with pytest.raises(UnprocessableError) as excinfo:
             print("DuplicateBob should not get created multiple times and returns a 422 error message")
             helper.given_new_fixed_user("DuplicateBob")
         error_string = str(excinfo.value)
-        assert "request failed (422)" in error_string
         print("There should be a JSON object in the error message that can be parsed")
-        json_object = error_string.split(":", 1)[1:][0]
-        parsed_json = json.loads(json_object)
+        parsed_json = json.loads(error_string)
         assert parsed_json['errorType'] == "validation"
         assert (
                 "'Username in use" in parsed_json['message']

--- a/test/test_user_thermal.py
+++ b/test/test_user_thermal.py
@@ -1,5 +1,7 @@
 import pytest
 
+from .testexception import AuthorizationError
+
 
 class TestUserThermal:
     def test_can_download_recording(self, helper):
@@ -53,22 +55,17 @@ class TestUserThermal:
         trouble = helper.given_new_user(self, "trouble")
 
         print("Then 'trouble' should not be able to upload a recording on the behalf of the device.")
-        try:
+        with pytest.raises(AuthorizationError):
             trouble.uploads_recording_for(device)
-            pytest.fail("On no 'trouble' could upload a recording on behalf of the device!")
-        except OSError:
-            pass
 
     def test_cant_download_recording_via_audio_api(self, helper):
         device = helper.given_new_device(self, "user-thermal-download")
         recording = device.has_recording()
 
-        user = helper.admin_user()
+        user = helper.given_new_user(self, "trouble")
 
-        print(
-            "\nA user should not be able to download the recording using the audio API"
-        )
-        user.cannot_download_audio(recording)
+        print("\nA user should not be able to download the recording using the audio API")
+        user.cannot_download_recording(recording)
 
         print("\nNor be able to see the recording through the audio query API")
         user.cannot_see_audio_recording(recording)

--- a/test/testexception.py
+++ b/test/testexception.py
@@ -1,3 +1,28 @@
 class TestException(Exception):
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
+
+
+class AuthenticationError(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+class AuthorizationError(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+class UnprocessableError(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
+def raise_specific_exception(response):
+    if response.status_code == 401:
+        raise AuthenticationError(response.text)
+    if response.status_code == 403:
+        raise AuthorizationError(response.text)
+    if response.status_code == 422:
+        raise UnprocessableError(response.text)
+    response.raise_for_status()

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -429,7 +429,8 @@ class RecordingQueryPromise:
 
     def from_(self, allRecordings):
         if not self._expected_recordings:
-            raise TestException("You must call 'can_only_see_recordings' before calling function 'from_list'.")
+            raise TestException(
+                "You must call 'can_only_see_recordings' before calling function 'from_list'.")
 
         ids = [testRecording.id_ for testRecording in self._expected_recordings]
         print("Then searching with {} should give only {}.".format(self._queryParams, ids))


### PR DESCRIPTION
Refactored auth handling to use standard Express middleware instead of validators, allowing us to directly return 401/403 status codes when relevant. Fixes #128 

Also refactored a lot of authorization handling in methods to throw a newly added AuthorizationError. Added a global error handler to the requestWrapper, allowing the Auth errors to bubble up directly and then be correctly handled.

Added custom Exceptions to the python test suite as well to more easily and specifically handle auth rejections.
Reworked all tests to expect a 403 when they should be forbidden rather than a 422.
Added a helper method to raise the correct exception if there is an error.