### PR TITLE
Fix a bug where the success boolean always returns true due to JS not doing multi comparisons

### DIFF
--- a/api/V1/responseUtil.js
+++ b/api/V1/responseUtil.js
@@ -40,7 +40,7 @@ function send(response, data) {
     return serverError(response, data);
   }
   var statusCode = data.statusCode;
-  data.success = (200 <= statusCode <= 299);
+  data.success = (200 <= statusCode && statusCode <= 299);
   delete data.statusCode;
   return response.status(statusCode).json(data);
 }


### PR DESCRIPTION
(200 <= 400<= 299) evaluates to true in JS land, as it just does the first bit then returns true (unlike Python).

Due to this our success boolean is true 100% of the time! I know the plan is to phase out the success flag, but might as well fix it anyway (hopefully nothing downstream depends on this bug 😁)

Copy paste the below in to you browser console for a demo:
```
statusCode=400;
console.log(200 <= statusCode <= 299);
console.log(200 <= statusCode && statusCode <= 299);
statusCode=200;
console.log(200 <= statusCode <= 299);
console.log(200 <= statusCode && statusCode <= 299);
```