### PR TITLE
Initial work for #199, support both legacy and new version of the PATCH endpoint.

### DIFF
--- a/api/customErrors.js
+++ b/api/customErrors.js
@@ -20,107 +20,100 @@ const log = require('../logging');
 const format = require('util').format;
 
 function errorHandler(err, request, response, next) { // eslint-disable-line
+  if (err instanceof SyntaxError && err.type === 'entity.parse.failed') {
+    err = new ClientError(err.message, 422); // Convert invalid JSON body error to UnprocessableEntity
+  }
   if (err instanceof CustomError) {
     log.warn(err.toString());
-    response.status(err.statusCode).json(err.toJson());
-    return;
+    return response.status(err.statusCode).json(err.toJson());
   }
   log.error(err);
   response.status(500).json({
-    message: "Server error.",
+    message: "Internal server error: " + err.name + ".",
     errorType: "server"
   });
 }
 
-function CustomError() {
-  this.statusCode = 500;
-}
-CustomError.prototype = new Error;
+class CustomError extends Error {
+  constructor() {
+    super();
+    this.name = this.constructor.name;
 
-function ValidationError(errors) {
-  this.name = "Validation";
-  this.statusCode = 422;
-  this.errors = errors;
-  this.flatten = () => {
+    this.statusCode = 500;
+    this.message = "Internal server error.";
+  }
+
+  getErrorType() {
+    if (this.name.endsWith("Error")) {
+      return this.name.toLowerCase().slice(0, -"Error".length);
+    }
+    return this.name.toLowerCase();
+  }
+
+  toString() {
+    return format("%s [%d]: %s.", this.name, this.statusCode, this.message);
+  }
+
+  toJson() {
+    return {
+      message: this.message,
+      errorType: this.getErrorType(),
+    };
+  }
+}
+
+class ValidationError extends CustomError {
+  constructor(errors) {
+    super();
+    this.statusCode = 422;
+    this.errors = errors;
+
     const mappedErrors = this.errors.mapped();
-    var errors = [];
+    const errorStrings = [];
     for (const name in mappedErrors) {
       const error = mappedErrors[name];
       if (typeof error.msg == "string") {
-        errors.push(error.msg);
+        errorStrings.push(error.msg);
       }
     }
-    return errors.join('; ');
-  };
-  this.toString = () => {
-    return format("%s error[%d]: %s.", this.name, this.statusCode, this.flatten());
-  };
-  this.toJson = () => {
+    this.message = errorStrings.join('; ');
+  }
+
+  toJson() {
     return {
-      errorType: this.name.toLowerCase(),
-      message: this.flatten(),
+      errorType: this.getErrorType(),
+      message: this.message,
       errors: this.errors.mapped(),
     };
-  };
-}
-ValidationError.prototype = new CustomError;
-ValidationError.prototype.constructor = ClientError;
-
-function AuthenticationError(message) {
-  this.name = "Authentication";
-  this.message = message;
-  this.statusCode = 401;
-  this.toString = () => {
-    return format("%s error[%d]: %s.", this.name, this.statusCode, this.message);
-  };
-  this.toJson = () => {
-    return {
-      message: this.message,
-      errorType: this.name.toLowerCase(),
-    };
-  };
-}
-
-AuthenticationError.prototype = new CustomError;
-AuthenticationError.prototype.constructor = AuthenticationError;
-
-function AuthorizationError(message) {
-  this.name = "AuthorizationError";
-  this.message = message;
-  this.statusCode = 403;
-  this.toString = () => {
-    return format("%s error[%d]: %s.", this.name, this.statusCode, this.message);
-  };
-  this.toJson = () => {
-    return {
-      message: this.message,
-      errorType: this.name.toLowerCase(),
-    };
-  };
-}
-
-AuthorizationError.prototype = new CustomError;
-AuthorizationError.prototype.constructor = AuthorizationError;
-
-function ClientError(message, statusCode) {
-  if (statusCode == undefined) {
-    statusCode = 400;
   }
-  this.name = "Client";
-  this.message = message;
-  this.statusCode = statusCode;
-  this.toString = () => {
-    return format("%s error[%d]: %s.", this.name, statusCode, message);
-  };
-  this.toJson = () => {
-    return {
-      message: message,
-      errorType: this.name.toLowerCase(),
-    };
-  };
 }
-ClientError.prototype = new CustomError;
-ClientError.prototype.constructor = ClientError;
+
+class AuthenticationError extends CustomError {
+  constructor(message) {
+    super();
+    this.message = message;
+    this.statusCode = 401;
+  }
+}
+
+class AuthorizationError extends CustomError {
+  constructor(message) {
+    super();
+    this.message = message;
+    this.statusCode = 403;
+  }
+}
+
+class ClientError extends CustomError {
+  constructor(message, statusCode) {
+    super();
+    if (typeof statusCode === 'undefined') {
+      statusCode = 400;
+    }
+    this.message = message;
+    this.statusCode = statusCode;
+  }
+}
 
 exports.ValidationError = ValidationError;
 exports.AuthenticationError = AuthenticationError;

--- a/api/middleware.js
+++ b/api/middleware.js
@@ -20,7 +20,6 @@ const models = require('../models');
 const format       = require('util').format;
 const log          = require('../logging');
 const customErrors = require('./customErrors');
-const {AuthorizationError, AuthenticationError} = require("./customErrors");
 const { body, validationResult, oneOf } = require('express-validator/check');
 
 
@@ -192,16 +191,7 @@ const requestWrapper = fn => (request, response, next) => {
     throw new customErrors.ValidationError(validationErrors);
   } else {
     Promise.resolve(fn(request, response, next))
-      .catch(e => {
-        if (e instanceof AuthenticationError) {
-          return response.status(401).json({messages: [e.message]});
-        }
-        if (e instanceof AuthorizationError) {
-          return response.status(403).json({messages: [e.message]});
-        }
-        throw e;
-      })
-      .catch((err) => { log.error("Unknown error: " + err + "\n" + err.stack); next();});
+      .catch(next);
   }
 };
 

--- a/models/User.js
+++ b/models/User.js
@@ -64,7 +64,9 @@ module.exports = function(sequelize, DataTypes) {
   var options = {
     hooks: {
       beforeValidate: beforeValidate,
-      afterValidate: afterValidate,
+      beforeCreate: beforeModify,
+      beforeUpdate: beforeModify,
+      beforeUpsert: beforeModify,
     }
   };
 
@@ -268,18 +270,10 @@ module.exports = function(sequelize, DataTypes) {
 // VALIDATION FUNCTIONS
 //----------------------
 
-function afterValidate(user) {
-  // TODO see if this can be done elsewhere, or when just validating the password.
-  return new Promise(function(resolve, reject) {
-    bcrypt.hash(user.password, 10, function(err, hash) {
-      if (err) {
-        reject(err);
-      } else {
-        user.password = hash;
-        resolve();
-      }
-    });
-  });
+async function beforeModify(user) {
+  if (user.changed('password')) {
+    user.password = await bcrypt.hash(user.password, 10);
+  }
 }
 
 function beforeValidate(user) {

--- a/test/apibase.py
+++ b/test/apibase.py
@@ -10,9 +10,9 @@ from .testexception import raise_specific_exception
 
 class APIBase:
     def __init__(self, logintype, baseurl, loginname, password="password"):
+        self._logintype = logintype
         self._baseurl = baseurl
         self._loginname = loginname
-        self._logintype = logintype
         self._password = password
 
     def login(self, email=None):

--- a/test/helper.py
+++ b/test/helper.py
@@ -21,6 +21,10 @@ class Helper:
         api = UserAPI(self.config.api_url, username, None, password).login()
         return TestUser(username, api)
 
+    def login_with_username_password(self, username, password):
+        api = UserAPI(self.config.api_url, username, None, password).login()
+        return TestUser(username, api)
+
     def login_with_email(self, username, email):
         password = self._make_password(username)
         api = UserAPI(self.config.api_url, username, email, password).login()
@@ -73,14 +77,16 @@ class Helper:
 
         raise TestException("Could not create username like '{}'".format(basename))
 
-    def given_new_fixed_user(self, username, email=None):
+    def given_new_fixed_user(self, username, email=None, password=None):
         if not email:
             email = username + "@email.com"
+        if not password:
+            password = self._make_password(username)
         api = UserAPI(
             self.config.api_url,
             username,
             email,
-            self._make_password(username),
+            password,
         ).register_as_new()
         self._print_actual_name(username)
         return TestUser(username, api, email)

--- a/test/test_middleware.py
+++ b/test/test_middleware.py
@@ -1,0 +1,29 @@
+from urllib.parse import urljoin
+
+import requests
+
+
+class TestMiddleware:
+    def test_invalid_json_body_in_post_returns_400_level_status(self, test_config):
+        print("When I POST to a valid endpoint with a malformed JSON body")
+
+        url = urljoin(test_config.api_url, "/api/v1/users")
+        response = requests.post(url, data="{")
+        print("  The response code should be 400 level")
+        assert 400 <= response.status_code < 500
+
+    def test_malformed_jwt_returns_400_level_status(self, test_config):
+        print("When I make a request that requires auth with a malformed JWT")
+
+        url = urljoin(test_config.api_url, "/api/v1/users")
+        response = requests.patch(url, data="{}", headers={"Authorization": "NOT VALID"})
+        print("  The response code should be 400 level")
+        assert 400 <= response.status_code < 500
+
+    def test_no_jwt_returns_401_status(self, test_config):
+        print("When I make a request that requires auth with no JWT")
+
+        url = urljoin(test_config.api_url, "/api/v1/users")
+        response = requests.patch(url, data="{}")
+        print("  The response code should be 401")
+        assert response.status_code == 401

--- a/test/testexception.py
+++ b/test/testexception.py
@@ -18,7 +18,14 @@ class UnprocessableError(Exception):
         Exception.__init__(self, *args, **kwargs)
 
 
+class BadRequestError(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+
+
 def raise_specific_exception(response):
+    if response.status_code == 400:
+        raise BadRequestError(response.text)
     if response.status_code == 401:
         raise AuthenticationError(response.text)
     if response.status_code == 403:

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -14,6 +14,16 @@ class TestUser:
         self.email = email
         self._group = None
 
+    def update(self, username=None, email=None, password=None):
+        data = {}
+        if username:
+            data["username"] = username
+        if email:
+            data["email"] = email
+        if password:
+            data["password"] = password
+        self._userapi.update_user(data)
+
     def reprocess_recordings(self, recordings, params=None):
         return self._userapi.reprocess_recordings(recordings, params)
 
@@ -181,7 +191,7 @@ class TestUser:
         return groupname
 
     def get_user_details(self, user):
-        self._userapi.get_user_details(user.username)
+        return self._userapi.get_user_details(user.username)
 
     def tag_recording(self, recording, tagDictionary):
         return self._userapi.tag_recording(recording.id_, tagDictionary)

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -56,6 +56,11 @@ class UserAPI(APIBase):
             filterOptions=filterOptions,
         )
 
+    def update_user(self, body):
+        url = urljoin(self._baseurl, "/api/v1/users")
+        response = requests.patch(url, data=body, headers=self._auth_header)
+        self._check_response(response)
+
     def get_recording(self, recording_id, params=None):
         url = urljoin(self._baseurl, "/api/v1/recordings/{}".format(recording_id))
         r = requests.get(url, headers=self._auth_header, params=params)


### PR DESCRIPTION
Added support for PATCHing /api/v1/users with fields directly in the body as described in #199.

Also fix #205, all fields are now properly validated.

Reworked the way Error constructors are handled to make use of new language features. This way is better in terms of output and is also more concise.

Removed catch block in middleware that didn't need to be there that I added in an earlier PR, can instead be caught in the global error handler.

Reworked the User hooks to handle password hashing as they were being double hashed with the rework of the validation.

Fixed response code for invalid JSON to return a 422 rather than a 500.

Added tests for user PATCH and POST to prevent regression. Added middleware tests to check some status codes are as expected.