### PR TITLE
Add various fields back to query results

### DIFF
--- a/models/Recording.js
+++ b/models/Recording.js
@@ -181,7 +181,7 @@ module.exports = function(sequelize, DataTypes) {
       ],
       limit: limit,
       offset: offset,
-      attributes: ['id', 'type', 'processingState', 'recordingDateTime', 'batteryLevel', 'duration', 'location', 'GroupId', 'DeviceId'],
+      attributes: Recording.queryGetAttributes
     };
 
     var queryResponse = await this.findAndCountAll(q);
@@ -546,6 +546,24 @@ module.exports = function(sequelize, DataTypes) {
     return track;
   };
 
+  // Attributes returned in recording query results.
+  Recording.queryGetAttributes = [
+    'id',
+    'type',
+    'recordingDateTime',
+    'rawFileSize',
+    'rawMimeType',
+    'fileSize',
+    'fileMimeType',
+    'processingState',
+    'duration',
+    'location',
+    'batteryLevel',
+    'DeviceId',
+    'GroupId',
+  ];
+
+  // Attributes returned when looking up a single recording.
   Recording.userGetAttributes = [
     'id',
     'rawFileSize',
@@ -569,6 +587,7 @@ module.exports = function(sequelize, DataTypes) {
     'comment',
   ];
 
+  // Fields that can be provided when uploading new recordings.
   Recording.apiSettableFields = [
     'type',
     'duration',

--- a/test/testdevice.py
+++ b/test/testdevice.py
@@ -66,6 +66,8 @@ class TestDevice:
         }
         filename = "files/small.mp3"
         recording_id = self._deviceapi.upload_audio_recording(filename, props)
+
+        props["rawMimeType"] = "audio/mpeg"
         return Recording(recording_id, props, filename)
 
     def _print_description(self, description):

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -58,6 +58,22 @@ class TestUser:
                 "User '{}' could not see any recordings.".format(self.username)
             )
 
+        # Check presence of various fields
+        r0 = recordings[0]
+        assert r0['id']
+        assert r0['type']
+        assert r0['recordingDateTime']
+        assert 'rawFileSize' in r0
+        assert r0['rawMimeType']
+        assert 'fileSize' in r0
+        assert 'fileMimeType' in r0
+        assert r0['processingState']
+        assert r0['duration'] > 0
+        assert 'location' in r0
+        assert 'batteryLevel' in r0
+        assert r0['DeviceId']
+        assert r0['GroupId']
+
         _errors = []
         for testRecording in expected_recordings:
             if not self._recording_in_list(recordings, testRecording):


### PR DESCRIPTION
A number of important fields where removed from the recordings search
API recently. This broke audio_download.py. These have been mostly
brought back and tests have been added for the search result fields.