### PR TITLE
Tag API clean up

### DIFF
--- a/DATA-MODEL.md
+++ b/DATA-MODEL.md
@@ -44,8 +44,8 @@ model.
     .---------------------.
     |         Tag         |
     | - id                |
-    | - animal            |
-    | - event             |
+    | - what              |
+    | - detail            |
     | - confidence        |
     | - startTime         |
     | - duration          |

--- a/api/V1/Tag.js
+++ b/api/V1/Tag.js
@@ -39,6 +39,7 @@ module.exports = function(app, baseUrl) {
    * - confidence
    * - startTime
    * - duration
+   * - version (hex coded, e.g. 0x0110 would be v1.10)
    *
    * @apiUse V1UserAuthorizationHeader
    *

--- a/api/V1/Tag.js
+++ b/api/V1/Tag.js
@@ -35,7 +35,8 @@ module.exports = function(app, baseUrl) {
    * @apiDescription This call is used to tag a recording. Only users that can
    * view a recording can tag it. It takes a `tag` field which contains a JSON
    * object string that may contain any of the following fields:
-   * - animal
+   * - what (legacy name "animal" is also supported)
+   * - detail (legacy name "event" is also supported)
    * - confidence
    * - startTime
    * - duration

--- a/api/V1/Tag.js
+++ b/api/V1/Tag.js
@@ -39,15 +39,6 @@ module.exports = function(app, baseUrl) {
    * - confidence
    * - startTime
    * - duration
-   * - number
-   * - trapType
-   * - trapInteractionTime
-   * - trapInteractionDuration
-   * - trappedTime
-   * - killedTime
-   * - poisionedTime
-   * - sex
-   * - age
    *
    * @apiUse V1UserAuthorizationHeader
    *

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -20,12 +20,11 @@ const jsonwebtoken = require('jsonwebtoken');
 const mime = require('mime');
 const _ = require('lodash');
 
-const { ClientError, AuthorizationError }   = require('../customErrors');
+const { ClientError }   = require('../customErrors');
 const config            = require('../../config');
 const models            = require('../../models');
 const responseUtil      = require('./responseUtil');
 const util              = require('./util');
-const log               = require('../../logging');
 
 
 function makeUploadHandler(mungeData) {
@@ -77,7 +76,7 @@ async function query(request, type) {
 }
 
 async function get(request, type) {
-  let recording = await models.Recording.get(
+  const recording = await models.Recording.get(
     request.user,
     request.params.id,
     models.Recording.Perms.VIEW,
@@ -157,11 +156,11 @@ async function addTag(request, response) {
     models.Recording.Perms.TAG
   );
   if (!recording) {
-    throw new ClientError("No such recording.")
+    throw new ClientError("No such recording.");
   }
 
   // If old tag fields are used, convert to new field names.
-  tag = handleLegacyTagFieldsForCreate(request.body.tag);
+  const tag = handleLegacyTagFieldsForCreate(request.body.tag);
 
   const tagInstance = models.Tag.build(_.pick(tag, models.Tag.apiSettableFields));
   tagInstance.set('RecordingId', request.body.recordingId);
@@ -186,10 +185,10 @@ function handleLegacyTagFieldsForCreate(tag) {
 function moveLegacyField(o, oldName, newName) {
   if (o[oldName]) {
     if (o[newName]) {
-      throw new Client(`can't specify both '${oldName}' and '${newName}' fields at the same time`);
+      throw new ClientError(`can't specify both '${oldName}' and '${newName}' fields at the same time`);
     }
     o[newName] = o[oldName];
-    delete o[oldName]
+    delete o[oldName];
   }
   return o;
 }

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -16,8 +16,9 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-const jsonwebtoken      = require('jsonwebtoken');
-const mime             = require('mime');
+const jsonwebtoken = require('jsonwebtoken');
+const mime = require('mime');
+const _ = require('lodash');
 
 const { ClientError, AuthorizationError }   = require('../customErrors');
 const config            = require('../../config');
@@ -169,9 +170,7 @@ async function addTag(request, response) {
   }
 
   // Build tag instance
-  const tagInstance = models.Tag.build(request.body.tag, {
-    fields: models.Tag.apiSettableFields,
-  });
+  const tagInstance = models.Tag.build(_.pick(request.body.tag, models.Tag.apiSettableFields));
   tagInstance.set('RecordingId', request.body.recordingId);
   if (request.user !== undefined) {
     tagInstance.set('taggerId', request.user.id);

--- a/migrations/20190605011805-tag-cleanup.js
+++ b/migrations/20190605011805-tag-cleanup.js
@@ -9,9 +9,15 @@ module.exports = {
     await queryInterface.removeColumn('Tags', 'age');
 
     await queryInterface.addColumn('Tags', 'version', { type: Sequelize.INTEGER, defaultValue: 0x0100 });
+
+    await queryInterface.renameColumn('Tags', 'animal', 'what');
+    await queryInterface.renameColumn('Tags', 'event', 'detail');
   },
 
   down: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('Tags', 'what', 'animal');
+    await queryInterface.renameColumn('Tags', 'detail', 'event');
+
     await queryInterface.removeColumn('Tags', 'version');
 
     await queryInterface.addColumn('Tags', 'number', Sequelize.INTEGER);

--- a/migrations/20190605011805-tag-cleanup.js
+++ b/migrations/20190605011805-tag-cleanup.js
@@ -7,12 +7,17 @@ module.exports = {
     await queryInterface.removeColumn('Tags', 'sex');
     await queryInterface.sequelize.query('DROP TYPE "enum_Tags_sex"');
     await queryInterface.removeColumn('Tags', 'age');
+
+    await queryInterface.addColumn('Tags', 'version', { type: Sequelize.INTEGER, defaultValue: 0x0100 });
   },
 
   down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Tags', 'version');
+
     await queryInterface.addColumn('Tags', 'number', Sequelize.INTEGER);
     await queryInterface.addColumn('Tags', 'trapType', Sequelize.STRING);
     await queryInterface.addColumn('Tags', 'sex', Sequelize.ENUM('M', 'F'));
     await queryInterface.addColumn('Tags', 'age', Sequelize.INTEGER);
+
   }
 };

--- a/migrations/20190605011805-tag-cleanup.js
+++ b/migrations/20190605011805-tag-cleanup.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Tags', 'number');
+    await queryInterface.removeColumn('Tags', 'trapType');
+    await queryInterface.removeColumn('Tags', 'sex');
+    await queryInterface.sequelize.query('DROP TYPE "enum_Tags_sex"');
+    await queryInterface.removeColumn('Tags', 'age');
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Tags', 'number', Sequelize.INTEGER);
+    await queryInterface.addColumn('Tags', 'trapType', Sequelize.STRING);
+    await queryInterface.addColumn('Tags', 'sex', Sequelize.ENUM('M', 'F'));
+    await queryInterface.addColumn('Tags', 'age', Sequelize.INTEGER);
+  }
+};

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -303,7 +303,11 @@ module.exports = function(sequelize, DataTypes) {
         ],
       },
       include: [
-        { model: models.Tag, include: [{association: 'tagger', attributes: ['username']}] },
+        {
+          model: models.Tag,
+          attributes: models.Tag.userGetAttributes,
+          include: [{association: 'tagger', attributes: ['username']}]
+        },
         { model: models.Device, where: {}, attributes: ["devicename", "id"] },
       ],
       attributes: this.userGetAttributes.concat(['rawFileKey']),

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -164,7 +164,7 @@ module.exports = function(sequelize, DataTypes) {
         { model: models.Group, where: {}, attributes: ["groupname"] },
         { model: models.Tag,
           where: {},
-          attributes: ["animal", "automatic", "event", "taggerId"],
+          attributes: ["what", "detail", "automatic", "taggerId"],
           required: false },
         { model: models.Track,
           where:{
@@ -238,7 +238,7 @@ module.exports = function(sequelize, DataTypes) {
   var recordingTaggedWith = (tags, tagTypeSql) => {
     let sql =  'SELECT "Recording"."id" FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id';
     if (tags) {
-      sql += ' AND (' + selectByTagWhat(tags, 'animal', true) + ')';
+      sql += ' AND (' + selectByTagWhat(tags, 'what', true) + ')';
     }
     if (tagTypeSql) {
       sql += ' AND (' + tagTypeSql + ')';
@@ -260,7 +260,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   // local
-  var selectByTagWhat = (tags, whatName, usesEvents) => {
+  var selectByTagWhat = (tags, whatName, usesDetail) => {
     if (!tags || tags.length === 0) {
       return null;
     }
@@ -269,9 +269,9 @@ module.exports = function(sequelize, DataTypes) {
     for (var i = 0; i < tags.length; i++) {
       var tag = tags[i];
       if (tag == "interesting") {
-        if (usesEvents) {
+        if (usesDetail) {
           parts.push('(("Tags"."' + whatName + '" IS NULL OR "Tags"."' + whatName + '"!=\'bird\') ' +
-           'AND ("Tags"."event" IS NULL OR "Tags"."event"!=\'false positive\'))');
+           'AND ("Tags"."detail" IS NULL OR "Tags"."detail"!=\'false positive\'))');
         }
         else {
           parts.push('("Tags"."' + whatName + '"!=\'bird\' AND "Tags"."' + whatName + '"!=\'false positive\')');
@@ -279,9 +279,9 @@ module.exports = function(sequelize, DataTypes) {
       }
       else {
         parts.push('"Tags"."' + whatName + '" = \'' + tag + '\'');
-        if (usesEvents) {
-          // the label could also be the event label not the animal label
-          parts.push('"Tags"."event" = \'' + tag + '\'');
+        if (usesDetail) {
+          // the label could also be the detail field not the what field
+          parts.push('"Tags"."detail" = \'' + tag + '\'');
         }
       }
     }

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -22,10 +22,10 @@ module.exports = function(sequelize, DataTypes) {
   var name = 'Tag';
 
   var attributes = {
-    animal: { // Name of animal for the Tag
+    what: {
       type: DataTypes.STRING,
     },
-    event: {
+    detail: {
       type: DataTypes.STRING,
     },
     confidence: { // 0: Not sure at all; 1: 100% positive
@@ -89,34 +89,33 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   Tag.prototype.getFrontendFields = function() {
-    var model = this;
     return {
-      id: model.getDataValue('id'),
-      animal: model.getDataValue('animal'),
-      confidence: model.getDataValue('confidence'),
-      startTime: model.getDataValue('startTime'),
-      duration: model.getDataValue('duration'),
-      event: model.getDataValue('event'),
+      id: this.id,
+      what: this.what,
+      detail: this.event,
+      confidence: this.confidence,
+      startTime: this.startTime,
+      duration: this.duration,
     };
   };
 
   Tag.userGetAttributes = Object.freeze([
     'id',
-    'animal',
+    'what',
+    'detail',
     'confidence',
     'startTime',
     'duration',
-    'event',
     'automatic',
     'version',
   ]);
 
   Tag.apiSettableFields = Object.freeze([
-    'animal',
+    'what',
+    'detail',
     'confidence',
     'startTime',
     'duration',
-    'event',
     'automatic',
     'version',
   ]);

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -97,6 +97,7 @@ module.exports = function(sequelize, DataTypes) {
     'duration',
     'automatic',
     'version',
+    'createdAt',
   ]);
 
   Tag.apiSettableFields = Object.freeze([

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -42,6 +42,11 @@ module.exports = function(sequelize, DataTypes) {
       allowNull: false,
       defaultValue: false,
     },
+    version: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0x0100,
+    },
   };
 
   var Tag = sequelize.define(name, attributes);
@@ -55,11 +60,11 @@ module.exports = function(sequelize, DataTypes) {
     models.Tag.belongsTo(models.User, {as: 'tagger'});
     models.Tag.belongsTo(models.Recording);
   };
-  
+
   Tag.getFromId = function(id, user, attributes) {
     util.GetFromId(id, user, attributes);
   };
-  
+
   Tag.deleteModelInstance = function(id, user) {
     util.deleteModelInstance(id, user);
   };
@@ -78,11 +83,11 @@ module.exports = function(sequelize, DataTypes) {
     if(recording == null){
       return false;
     }
-    
+
     await tag.destroy();
     return true;
   };
-  
+
   Tag.prototype.getFrontendFields = function() {
     var model = this;
     return {
@@ -91,28 +96,30 @@ module.exports = function(sequelize, DataTypes) {
       confidence: model.getDataValue('confidence'),
       startTime: model.getDataValue('startTime'),
       duration: model.getDataValue('duration'),
-      number: model.getDataValue('number'),
-      trapType: model.getDataValue('trapType'),
       event: model.getDataValue('event'),
-      sex: model.getDataValue('sex'),
-      age: model.getDataValue('age'),
     };
   };
-  
-  Tag.apiUpdateableFields = [];
-  
-  Tag.apiSettableFields = [
+
+  Tag.userGetAttributes = Object.freeze([
+    'id',
     'animal',
     'confidence',
     'startTime',
     'duration',
-    'number',
-    'trapType',
     'event',
-    'sex',
-    'age',
     'automatic',
-  ];
-  
+    'version',
+  ]);
+
+  Tag.apiSettableFields = Object.freeze([
+    'animal',
+    'confidence',
+    'startTime',
+    'duration',
+    'event',
+    'automatic',
+    'version',
+  ]);
+
   return Tag;
 };

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -22,14 +22,13 @@ module.exports = function(sequelize, DataTypes) {
   var name = 'Tag';
 
   var attributes = {
-
     animal: { // Name of animal for the Tag
       type: DataTypes.STRING,
     },
     event: {
       type: DataTypes.STRING,
     },
-    confidence: { // 0-Not sure at all, 1-100% positive.
+    confidence: { // 0: Not sure at all; 1: 100% positive
       type: DataTypes.FLOAT,
     },
     startTime: { // Start time of the tag in the linked recording in seconds
@@ -37,18 +36,6 @@ module.exports = function(sequelize, DataTypes) {
     },
     duration: { // duration of the tag
       type: DataTypes.FLOAT,
-    },
-    number: { // Number of animals in tag
-      type: DataTypes.INTEGER,
-    },
-    trapType: {
-      type: DataTypes.STRING,
-    },
-    sex: { // What sex is the animal, null if don't know.
-      type: DataTypes.ENUM('F', 'M'),
-    },
-    age: { // Guessed age in weeks of animal
-      type: DataTypes.INTEGER,
     },
     automatic: { // True if the tag was automatically generated.
       type: DataTypes.BOOLEAN,

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -88,17 +88,6 @@ module.exports = function(sequelize, DataTypes) {
     return true;
   };
 
-  Tag.prototype.getFrontendFields = function() {
-    return {
-      id: this.id,
-      what: this.what,
-      detail: this.event,
-      confidence: this.confidence,
-      startTime: this.startTime,
-      duration: this.duration,
-    };
-  };
-
   Tag.userGetAttributes = Object.freeze([
     'id',
     'what',

--- a/test/recording.py
+++ b/test/recording.py
@@ -16,17 +16,18 @@ class Recording:
     def __setitem__(self, name, value):
         self.props[name] = value
 
-    def is_tagged_as(self, animal):
-        return TagPromise(self, animal)
+    def is_tagged_as(self, animal, **data):
+        return TagPromise(self, animal, data)
 
 
 class TagPromise:
-    def __init__(self, recording, animal):
+    def __init__(self, recording, animal, data=None):
         self._recording = recording
         if animal == 'false positive':
             self._tag_data = {"event": 'false positive'}
         else:
             self._tag_data = {"animal": animal}
+        self._tag_data.update(data)
         print("  which is tagged as a {}".format(animal), end="")
 
     def by(self, user):

--- a/test/recording.py
+++ b/test/recording.py
@@ -16,28 +16,24 @@ class Recording:
     def __setitem__(self, name, value):
         self.props[name] = value
 
-    def is_tagged_as(self, what, **data):
-        return TagPromise(self, what, data)
+    def is_tagged_as(self, **data):
+        return TagPromise(self, data)
 
 
 class TagPromise:
-    def __init__(self, recording, what, data=None):
+    def __init__(self, recording, tag):
         self._recording = recording
-        if what == 'false positive':
-            self._tag_data = {"detail": 'false positive'}
-        else:
-            self._tag_data = {"what": what}
-        self._tag_data.update(data)
-        print("  which is tagged as a {}".format(what), end="")
+        if tag.get('what') == 'false positive':
+            tag['detail'] = 'false positive'
+            del tag['what']
+        self._tag = tag
 
     def by(self, user):
-        print(" by {}".format(user.username))
-        return user.tag_recording(self._recording, self._tag_data)
+        return user.tag_recording(self._recording, self._tag)
 
     def byAI(self, user):
-        print(" by {}".format("by AI"))
-        self._tag_data["automatic"] = True
-        return user.tag_recording(self._recording, self._tag_data)
+        self._tag["automatic"] = True
+        return user.tag_recording(self._recording, self._tag)
 
 
 def slurp(filename):

--- a/test/recording.py
+++ b/test/recording.py
@@ -16,19 +16,19 @@ class Recording:
     def __setitem__(self, name, value):
         self.props[name] = value
 
-    def is_tagged_as(self, animal, **data):
-        return TagPromise(self, animal, data)
+    def is_tagged_as(self, what, **data):
+        return TagPromise(self, what, data)
 
 
 class TagPromise:
-    def __init__(self, recording, animal, data=None):
+    def __init__(self, recording, what, data=None):
         self._recording = recording
-        if animal == 'false positive':
-            self._tag_data = {"event": 'false positive'}
+        if what == 'false positive':
+            self._tag_data = {"detail": 'false positive'}
         else:
-            self._tag_data = {"animal": animal}
+            self._tag_data = {"what": what}
         self._tag_data.update(data)
-        print("  which is tagged as a {}".format(animal), end="")
+        print("  which is tagged as a {}".format(what), end="")
 
     def by(self, user):
         print(" by {}".format(user.username))

--- a/test/test_global_permissions.py
+++ b/test/test_global_permissions.py
@@ -92,7 +92,7 @@ class TestGlobalPermission:
         fred.update_recording(recording, comment="testing")
 
         print("  And tag the recording")
-        fred.tag_recording(recording, {"animal": "cat"})
+        fred.tag_recording(recording, {"what": "cat"})
 
         print("  And delete the recording")
         fred.delete_recording(recording)

--- a/test/test_recordings_get_by_tags.py
+++ b/test/test_recordings_get_by_tags.py
@@ -19,7 +19,7 @@ class TestRecordingsGetByTags:
 
         # ai and human tags different - one track, on recording.
         ai_human_possum3 = makeTrackTaggedRecording(device, helper, lucy, [[None, "possum"]])
-        ai_human_possum3.is_tagged_as("possum").byAI(helper.admin_user())
+        ai_human_possum3.is_tagged_as(what="possum").byAI(helper.admin_user())
 
         all = [untagged, ai_possum, ai_possum2, human_possum, human_possum2, ai_human_possum,
                ai_human_possum2, ai_human_possum3]
@@ -110,10 +110,10 @@ def makeTaggedRecording(device, helper, ai_tags, tagger, human_tags):
     recording = device.has_recording()
     recording.name = "ai:" + str(ai_tags) + " human: " + str(human_tags)
     for tag in ai_tags:
-        recording.is_tagged_as(tag).byAI(helper.admin_user())
+        recording.is_tagged_as(what=tag).byAI(helper.admin_user())
 
     for tag in human_tags:
-        recording.is_tagged_as(tag).by(tagger)
+        recording.is_tagged_as(what=tag).by(tagger)
     return recording
 
 

--- a/test/test_tagging.py
+++ b/test/test_tagging.py
@@ -8,20 +8,20 @@ class TestTagging:
         device = helper.given_new_device(self, "Rec", group, description="")
         untagged = device.has_recording()
 
-        tag = untagged.is_tagged_as("possum").by(lucy)
+        tag = untagged.is_tagged_as(what="possum").by(lucy)
         lucy.delete_recording_tag(tag["tagId"])
 
-        tag = untagged.is_tagged_as("cat").by(lucy)
+        tag = untagged.is_tagged_as(what="cat").by(lucy)
         admin.delete_recording_tag(tag["tagId"])
 
-        tag = untagged.is_tagged_as("cat").by(lucy)
+        tag = untagged.is_tagged_as(what="cat").by(lucy)
         sophie.cannot_delete_recording_tag(tag["tagId"])
 
     def test_default_tag_version(self, helper):
         "Ensure the default version is set if not supplied"
         recording = helper.given_new_device(self).has_recording()
         admin = helper.admin_user()
-        recording.is_tagged_as("possum").by(admin)
+        recording.is_tagged_as(what="possum").by(admin)
 
         props = admin.get_recording(recording)
         assert len(props["Tags"]) == 1
@@ -30,8 +30,46 @@ class TestTagging:
     def test_set_tag_version(self, helper):
         recording = helper.given_new_device(self).has_recording()
         admin = helper.admin_user()
-        recording.is_tagged_as("possum", version=0x0201).by(admin)
+        recording.is_tagged_as(what="possum", version=0x0201).by(admin)
 
         props = admin.get_recording(recording)
         assert len(props["Tags"]) == 1
         assert props["Tags"][0]["version"] == 0x0201
+
+    def test_legacy_tag_fields(self, helper):
+        recording = helper.given_new_device(self).has_recording()
+        admin = helper.admin_user()
+
+        # Set tags using old legacy names.
+        recording.is_tagged_as(animal="possum", event="chillin").by(admin)
+
+        props = admin.get_recording(recording)
+        assert len(props["Tags"]) == 1
+        tag = props["Tags"][0]
+
+        assert tag["what"] == "possum"
+        assert tag["animal"] == "possum"  # alias for "what"
+
+        assert tag["detail"] == "chillin"
+        assert tag["event"] == "chillin"  # alias for "detail"
+
+    def test_legacy_tag_fields_in_query(self, helper):
+        recording = helper.given_new_device(self).has_recording()
+        admin = helper.admin_user()
+        recording.is_tagged_as(what="foo", detail="bar").by(admin)
+
+        # Query recent recordings and find the entry.
+        results = [
+            r for r in admin.query_recordings(limit=5) if r["id"] == recording.id_
+        ]
+        assert len(results) == 1
+
+        tags = results[0]["Tags"]
+        assert len(tags) == 1
+        tag = tags[0]
+
+        assert tag["what"] == "foo"
+        assert tag["animal"] == "foo"  # alias for "what"
+
+        assert tag["detail"] == "bar"
+        assert tag["event"] == "bar"  # alias for "detail"

--- a/test/test_tagging.py
+++ b/test/test_tagging.py
@@ -5,7 +5,7 @@ class TestTagging:
         sophie = helper.given_new_user(self, "sophie")
 
         group = lucy.create_group(helper.make_unique_group_name(self, "lucys_group"))
-        device = helper.given_new_device(self, "Rec", group, description='')
+        device = helper.given_new_device(self, "Rec", group, description="")
         untagged = device.has_recording()
 
         tag = untagged.is_tagged_as("possum").by(lucy)
@@ -16,3 +16,22 @@ class TestTagging:
 
         tag = untagged.is_tagged_as("cat").by(lucy)
         sophie.cannot_delete_recording_tag(tag["tagId"])
+
+    def test_default_tag_version(self, helper):
+        "Ensure the default version is set if not supplied"
+        recording = helper.given_new_device(self).has_recording()
+        admin = helper.admin_user()
+        recording.is_tagged_as("possum").by(admin)
+
+        props = admin.get_recording(recording)
+        assert len(props["Tags"]) == 1
+        assert props["Tags"][0]["version"] == 0x0100
+
+    def test_set_tag_version(self, helper):
+        recording = helper.given_new_device(self).has_recording()
+        admin = helper.admin_user()
+        recording.is_tagged_as("possum", version=0x0201).by(admin)
+
+        props = admin.get_recording(recording)
+        assert len(props["Tags"]) == 1
+        assert props["Tags"][0]["version"] == 0x0201

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -231,8 +231,7 @@ class UserAPI(APIBase):
         params.setdefault("limit", 100)
         params.setdefault("offset", 0)
 
-        return_json = params.get("return_json", False)
-        params.pop("return_json", None)
+        return_json = params.pop("return_json", False)
         req_params = {}
         for name, value in params.items():
             if value is not None:


### PR DESCRIPTION
- Unused tag fields have been removed:
  - `number`
  - `trapType`
  - `sex`
  - `age`
- New `version` field added
- `animal` renamed to `what`
- `event` renamed to `detail`
- `animal` and `event` are supported for tag creation and reported as aliases when retrieving recordings and querying