### PR TITLE
Fix #231 sequelize params and #215 apidoc and remove var in favour of let/const

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,8 +6,9 @@ parserOptions:
 extends: 'eslint:recommended'
 rules:
   indent:
-    - warn
+    - error
     - 2
+    - SwitchCase: 1
   linebreak-style:
     - error
     - unix
@@ -21,5 +22,7 @@ rules:
     - always
   no-console:
     - off
+  no-var:
+    - error
   prefer-const:
     - error

--- a/Server.js
+++ b/Server.js
@@ -1,16 +1,16 @@
-var express = require("express");
-var bodyParser = require("body-parser");
-var passport = require("passport");
-var process = require("process");
-var http = require("http");
+const express = require("express");
+const bodyParser = require("body-parser");
+const passport = require("passport");
+const process = require("process");
+const http = require("http");
 
-var configPath = "./config/app.js";
+let configPath = "./config/app.js";
 process.argv.forEach((val, index) => {
   if (index > 1) {
     if (val.toLowerCase().startsWith("--config=")) {
       configPath = val.split("=")[1];
     } else {
-      var error =
+      const error =
         "Cannot parse '" +
         val +
         "'.  The only accepted parameter is --config=<path-to-config-file> ";
@@ -19,15 +19,15 @@ process.argv.forEach((val, index) => {
   }
 });
 
-var config = require("./config");
+const config = require("./config");
 config.loadConfig(configPath);
 
-var modelsUtil = require("./models/util/util");
-var log = require("./logging");
-var models = require("./models");
+const modelsUtil = require("./models/util/util");
+const log = require("./logging");
+const models = require("./models");
 
 log.info("Starting Full Noise.");
-var app = express();
+const app = express();
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(passport.initialize());
@@ -56,7 +56,7 @@ require("./api/V1")(app);
 app.use(require("./api/customErrors").errorHandler);
 
 // Add file processing API.
-var fileProcessingApp = express();
+const fileProcessingApp = express();
 fileProcessingApp.use(bodyParser.urlencoded({ extended: false }));
 require("./api/fileProcessing")(fileProcessingApp);
 http.createServer(fileProcessingApp).listen(config.fileProcessing.port);
@@ -93,8 +93,8 @@ function openHttpServer(app) {
 // and reject if connection failed.
 function checkS3Connection() {
   return new Promise(function(resolve, reject) {
-    var s3 = modelsUtil.openS3();
-    var params = { Bucket: config.s3.bucket };
+    const s3 = modelsUtil.openS3();
+    const params = {Bucket: config.s3.bucket};
     log.info("Connecting to S3.....");
     s3.headBucket(params, function(err) {
       if (err) {

--- a/api/V1/Admin.js
+++ b/api/V1/Admin.js
@@ -23,7 +23,7 @@ const responseUtil = require("./responseUtil");
 const { param, body } = require("express-validator/check");
 
 module.exports = function(app, baseUrl) {
-  var apiUrl = baseUrl + "/admin";
+  const apiUrl = baseUrl + "/admin";
 
   /**
    * @api {patch} /api/v1/admin/global_permission/:username Update user global permissions

--- a/api/V1/AudioRecording.js
+++ b/api/V1/AudioRecording.js
@@ -27,7 +27,7 @@ const recordingUtil = require("./recordingUtil");
 const responseUtil = require("./responseUtil");
 
 module.exports = function(app, baseUrl) {
-  var apiUrl = baseUrl + "/audiorecordings";
+  const apiUrl = baseUrl + "/audiorecordings";
 
   // Massage fields sent to the legacy AudioRecordings API so that
   // they work in the Recordings schema.
@@ -95,7 +95,7 @@ module.exports = function(app, baseUrl) {
       middleware.parseJSON("data", body)
     ],
     middleware.requestWrapper(async (request, response) => {
-      var updated = await models.Recording.updateOne(
+      const updated = await models.Recording.updateOne(
         request.user,
         request.params.id,
         request.body.data
@@ -171,7 +171,7 @@ module.exports = function(app, baseUrl) {
       request.query.offset = request.headers.offset;
 
       const qresult = await recordingUtil.query(request, "audio");
-      var result = {
+      const result = {
         rows: [],
         limit: request.query.limit,
         offset: request.query.offset,

--- a/api/V1/AuthenticateDevice.js
+++ b/api/V1/AuthenticateDevice.js
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 const jwt = require("jsonwebtoken");
-var config = require("../../config");
+const config = require("../../config");
 const responseUtil = require("./responseUtil");
 const middleware = require("../middleware");
 const { body } = require("express-validator/check");
@@ -43,8 +43,8 @@ module.exports = function(app) {
         request.body.password
       );
       if (passwordMatch) {
-        var data = request.body.device.getJwtDataValues();
-        var token = "JWT " + jwt.sign(data, config.server.passportSecret);
+        const data = request.body.device.getJwtDataValues();
+        const token = "JWT " + jwt.sign(data, config.server.passportSecret);
         return responseUtil.send(response, {
           statusCode: 200,
           messages: ["Successful login."],

--- a/api/V1/AuthenticateUser.js
+++ b/api/V1/AuthenticateUser.js
@@ -58,7 +58,7 @@ module.exports = function(app) {
       );
       if (passwordMatch) {
         const userData = await request.body.user.getDataValues();
-        var data = request.body.user.getJwtDataValues();
+        const data = request.body.user.getJwtDataValues();
         data._type = "user";
         return responseUtil.send(response, {
           statusCode: 200,

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -25,7 +25,7 @@ const auth = require("../auth");
 const { query, body } = require("express-validator/check");
 
 module.exports = function(app, baseUrl) {
-  var apiUrl = baseUrl + "/devices";
+  const apiUrl = baseUrl + "/devices";
 
   /**
    * @api {post} /api/v1/devices Register a new device
@@ -168,7 +168,7 @@ module.exports = function(app, baseUrl) {
       body("admin").isIn([true, false])
     ],
     middleware.requestWrapper(async (request, response) => {
-      var added = await models.Device.addUserToDevice(
+      const added = await models.Device.addUserToDevice(
         request.user,
         request.body.device,
         request.body.user,
@@ -213,7 +213,7 @@ module.exports = function(app, baseUrl) {
       middleware.getUserByNameOrId(body)
     ],
     middleware.requestWrapper(async function(request, response) {
-      var removed = await models.Device.removeUserFromDevice(
+      const removed = await models.Device.removeUserFromDevice(
         request.user,
         request.body.device,
         request.body.user

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -69,10 +69,15 @@ module.exports = function(app, baseUrl) {
    * @api {get} /api/v1/devices Get list of devices
    * @apiName GetDevices
    * @apiGroup Device
+   * @apiDescription Returns all devices the user can access
+   * through both group membership and direct assignment.
    *
    * @apiUse V1UserAuthorizationHeader
    *
    * @apiUse V1ResponseSuccess
+   * @apiSuccess {JSON} devices Object with two entries, a count integer that is the number of rows returned, and
+   * rows, which is an array of devices accessible.
+   * Each element in rows includes `devicename` (string), `id` (int), and `Users` which is an array of Users with permissions on that device.
    *
    * @apiUse V1ResponseError
    */
@@ -80,7 +85,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [auth.authenticateUser],
     middleware.requestWrapper(async (request, response) => {
-      var devices = await models.Device.allForUser(request.user);
+      const devices = await models.Device.allForUser(request.user);
       return responseUtil.send(response, {
         devices: devices,
         statusCode: 200,

--- a/api/V1/Event.js
+++ b/api/V1/Event.js
@@ -23,7 +23,7 @@ const auth = require("../auth");
 const { body, query, oneOf } = require("express-validator/check");
 
 module.exports = function(app, baseUrl) {
-  var apiUrl = baseUrl + "/events";
+  const apiUrl = baseUrl + "/events";
 
   /**
    * @api {post} /api/v1/events Add new events
@@ -64,18 +64,18 @@ module.exports = function(app, baseUrl) {
       )
     ],
     middleware.requestWrapper(async (request, response) => {
-      var detailsId = request.body.eventDetailId;
+      let detailsId = request.body.eventDetailId;
       if (!detailsId) {
-        var description = request.body.description;
-        var detail = await models.DetailSnapshot.getOrCreateMatching(
+        const description = request.body.description;
+        const detail = await models.DetailSnapshot.getOrCreateMatching(
           description.type,
           description.details
         );
         detailsId = detail.id;
       }
 
-      var eventList = [];
-      var count = 0;
+      const eventList = [];
+      let count = 0;
 
       request.body.dateTimes.forEach(function(time) {
         eventList.push({
@@ -147,7 +147,7 @@ module.exports = function(app, baseUrl) {
       query.offset = query.offset || 0;
       query.limit = query.limit || 100;
 
-      var result = await models.Event.query(
+      const result = await models.Event.query(
         request.user,
         query.startTime,
         query.endTime,

--- a/api/V1/File.js
+++ b/api/V1/File.js
@@ -26,7 +26,7 @@ const auth = require("../auth");
 const { query, param } = require("express-validator/check");
 
 module.exports = (app, baseUrl) => {
-  var apiUrl = baseUrl + "/files";
+  const apiUrl = baseUrl + "/files";
 
   /**
    * @api {post} /api/v1/files Adds a new file.
@@ -90,7 +90,7 @@ module.exports = (app, baseUrl) => {
         request.query.limit = "100";
       }
 
-      var result = await models.File.query(
+      const result = await models.File.query(
         request.query.where,
         request.query.offset,
         request.query.limit,
@@ -127,9 +127,9 @@ module.exports = (app, baseUrl) => {
     apiUrl + "/:id",
     [auth.authenticateAny, middleware.getFileById(param)],
     middleware.requestWrapper(async (request, response) => {
-      var file = request.body.file;
+      const file = request.body.file;
 
-      var downloadFileData = {
+      const downloadFileData = {
         _type: "fileDownload",
         key: file.fileKey
       };

--- a/api/V1/File.js
+++ b/api/V1/File.js
@@ -49,11 +49,9 @@ module.exports = (app, baseUrl) => {
     [auth.authenticateUser],
     middleware.requestWrapper(
       util.multipartUpload((request, data, key) => {
-        var dbRecord = models.File.build(data, {
-          fields: models.File.apiSettableFields
-        });
-        dbRecord.set("UserId", request.user.id);
-        dbRecord.set("fileKey", key);
+        const dbRecord = models.File.buildSafely(data);
+        dbRecord.UserId = request.user.id;
+        dbRecord.fileKey = key;
         return dbRecord;
       })
     )

--- a/api/V1/Group.js
+++ b/api/V1/Group.js
@@ -23,7 +23,7 @@ const auth = require("../auth");
 const { query, body } = require("express-validator/check");
 
 module.exports = function(app, baseUrl) {
-  var apiUrl = baseUrl + "/groups";
+  const apiUrl = baseUrl + "/groups";
 
   /**
    * @api {post} /api/v1/groups Create a new group
@@ -77,7 +77,10 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [auth.authenticateUser, middleware.parseJSON("where", query)],
     middleware.requestWrapper(async (request, response) => {
-      var groups = await models.Group.query(request.query.where, request.user);
+      const groups = await models.Group.query(
+        request.query.where,
+        request.user
+      );
       return responseUtil.send(response, {
         statusCode: 200,
         messages: [],

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -25,7 +25,7 @@ const recordingUtil = require("./recordingUtil");
 const responseUtil = require("./responseUtil");
 
 module.exports = (app, baseUrl) => {
-  var apiUrl = baseUrl + "/recordings";
+  const apiUrl = baseUrl + "/recordings";
 
   /**
    * @apiDefine RecordingParams
@@ -237,7 +237,7 @@ module.exports = (app, baseUrl) => {
       middleware.parseJSON("updates", body)
     ],
     middleware.requestWrapper(async (request, response) => {
-      var updated = await models.Recording.updateOne(
+      const updated = await models.Recording.updateOne(
         request.user,
         request.params.id,
         request.body.updates

--- a/api/V1/Schedule.js
+++ b/api/V1/Schedule.js
@@ -23,7 +23,7 @@ const middleware = require("../middleware");
 const auth = require("../auth");
 
 module.exports = (app, baseUrl) => {
-  var apiUrl = baseUrl + "/schedules";
+  const apiUrl = baseUrl + "/schedules";
 
   /**
    * @api {post} /api/v1/schedules Adds a new schedule
@@ -117,7 +117,7 @@ module.exports = (app, baseUrl) => {
 };
 
 async function getSchedule(device, response, user = null) {
-  var schedule = { schedule: {} };
+  let schedule = { schedule: {} };
 
   if (device.ScheduleId) {
     schedule = await models.Schedule.findByPk(device.ScheduleId);
@@ -131,7 +131,7 @@ async function getSchedule(device, response, user = null) {
   }
 
   // get all the users devices that are also associated with this same schedule
-  var devices = [];
+  let devices = [];
   if (user && device.ScheduleId) {
     devices = await models.Device.onlyUsersDevicesMatching(user, {
       ScheduleId: device.ScheduleId

--- a/api/V1/Schedule.js
+++ b/api/V1/Schedule.js
@@ -50,10 +50,10 @@ module.exports = (app, baseUrl) => {
       auth.userCanAccessDevices
     ],
     middleware.requestWrapper(async function(request, response) {
-      var deviceIds = request.body.devices;
+      const deviceIds = request.body.devices;
 
-      var instance = models.Schedule.build(request.body, ["schedule"]);
-      instance.set("UserId", request.user.id);
+      const instance = models.Schedule.buildSafely(request.body);
+      instance.UserId = request.user.id;
       // TODO make the device and schedule changes apply in a single transaction
       await instance.save();
 

--- a/api/V1/Tag.js
+++ b/api/V1/Tag.js
@@ -25,7 +25,7 @@ const recordingUtil = require("./recordingUtil");
 const responseUtil = require("./responseUtil");
 
 module.exports = function(app, baseUrl) {
-  var apiUrl = baseUrl + "/tags";
+  const apiUrl = baseUrl + "/tags";
 
   /**
    * @api {post} /api/v1/tags Adds a new tag
@@ -80,7 +80,7 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [auth.authenticateUser, body("tagId").isInt()],
     middleware.requestWrapper(async function(request, response) {
-      var tagDeleteResult = await models.Tag.deleteFromId(
+      const tagDeleteResult = await models.Tag.deleteFromId(
         request.body.tagId,
         request.user
       );

--- a/api/V1/User.js
+++ b/api/V1/User.js
@@ -27,7 +27,7 @@ const { matchedData } = require("express-validator/filter");
 const { ClientError } = require("../customErrors");
 
 module.exports = function(app, baseUrl) {
-  var apiUrl = baseUrl + "/users";
+  const apiUrl = baseUrl + "/users";
 
   /**
    * @api {post} /api/v1/users Register a new user
@@ -58,14 +58,14 @@ module.exports = function(app, baseUrl) {
       middleware.checkNewPassword("password")
     ],
     middleware.requestWrapper(async (request, response) => {
-      var user = await models.User.create({
+      const user = await models.User.create({
         username: request.body.username,
         password: request.body.password,
         email: request.body.email
       });
 
-      var jwtData = user.getJwtDataValues();
-      var userData = await user.getDataValues();
+      const jwtData = user.getJwtDataValues();
+      const userData = await user.getDataValues();
 
       return responseUtil.send(response, {
         statusCode: 200,

--- a/api/V1/index.js
+++ b/api/V1/index.js
@@ -16,11 +16,11 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var fs = require("fs");
-var path = require("path");
+const fs = require("fs");
+const path = require("path");
 
 module.exports = function(app) {
-  var apiRouts = fs.readdirSync(__dirname);
+  const apiRouts = fs.readdirSync(__dirname);
 
   // Remove files that are not added to app directly
   apiRouts.splice(apiRouts.indexOf("index.js"), 1);
@@ -29,7 +29,7 @@ module.exports = function(app) {
   apiRouts.splice(apiRouts.indexOf("recordingUtil.js"), 1);
   apiRouts.splice(apiRouts.indexOf("apidoc.js"), 1);
 
-  for (var i in apiRouts) {
+  for (const i in apiRouts) {
     require(path.join(__dirname, apiRouts[i]))(app, "/api/v1");
   }
 };

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const jsonwebtoken = require("jsonwebtoken");
 const mime = require("mime");
-const _ = require("lodash");
-
 const { ClientError } = require("../customErrors");
 const config = require("../../config");
 const models = require("../../models");
@@ -115,7 +113,7 @@ async function get(request, type) {
 }
 
 async function delete_(request, response) {
-  var deleted = await models.Recording.deleteOne(
+  const deleted = await models.Recording.deleteOne(
     request.user,
     request.params.id
   );
@@ -133,7 +131,7 @@ async function delete_(request, response) {
 }
 
 function guessRawMimeType(type, filename) {
-  var mimeType = mime.getType(filename);
+  const mimeType = mime.getType(filename);
   if (mimeType) {
     return mimeType;
   }
@@ -210,16 +208,16 @@ const statusCode = {
 // will mark each recording to be reprocessed
 async function reprocessAll(request, response) {
   const recordings = request.body.recordings;
-  var responseMessage = {
+  const responseMessage = {
     statusCode: 200,
     messages: [],
     reprocessed: [],
     fail: []
   };
 
-  var status = 0;
-  for (var i = 0; i < recordings.length; i++) {
-    var resp = await reprocessRecording(request.user, recordings[i]);
+  let status = 0;
+  for (let i = 0; i < recordings.length; i++) {
+    const resp = await reprocessRecording(request.user, recordings[i]);
     if (resp.statusCode != 200) {
       status = status | statusCode.Fail;
       responseMessage.messages.push(resp.messages[0]);
@@ -276,7 +274,10 @@ async function reprocessRecording(user, recording_id) {
 
 // reprocess a recording defined by request.user and request.params.id
 async function reprocess(request, response) {
-  var responseInfo = await reprocessRecording(request.user, request.params.id);
+  const responseInfo = await reprocessRecording(
+    request.user,
+    request.params.id
+  );
   responseUtil.send(response, responseInfo);
 }
 

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -32,19 +32,14 @@ function makeUploadHandler(mungeData) {
       data = mungeData(data);
     }
 
-    const recording = models.Recording.build(data, {
-      fields: models.Recording.apiSettableFields
-    });
-    recording.set("rawFileKey", key);
-    recording.set("rawMimeType", guessRawMimeType(data.type, data.filename));
-    recording.set("DeviceId", request.device.id);
-    recording.set("GroupId", request.device.GroupId);
-    recording.set(
-      "processingState",
-      models.Recording.processingStates[data.type][0]
-    );
+    const recording = models.Recording.buildSafely(data);
+    recording.rawFileKey = key;
+    recording.rawMimeType = guessRawMimeType(data.type, data.filename);
+    recording.DeviceId = request.device.id;
+    recording.GroupId = request.device.GroupId;
+    recording.processingState = models.Recording.processingStates[data.type][0];
     if (typeof request.device.public === "boolean") {
-      recording.set("public", request.device.public);
+      recording.public = request.device.public;
     }
     return recording;
   });
@@ -160,12 +155,10 @@ async function addTag(user, recording, tag, response) {
   // If old tag fields are used, convert to new field names.
   tag = handleLegacyTagFieldsForCreate(tag);
 
-  const tagInstance = models.Tag.build(
-    _.pick(tag, models.Tag.apiSettableFields)
-  );
-  tagInstance.set("RecordingId", recording.id);
+  const tagInstance = models.Tag.buildSafely(tag);
+  tagInstance.RecordingId = recording.id;
   if (user) {
-    tagInstance.set("taggerId", user.id);
+    tagInstance.taggerId = user.id;
   }
   await tagInstance.save();
 

--- a/api/V1/responseUtil.js
+++ b/api/V1/responseUtil.js
@@ -16,9 +16,9 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var log = require("../../logging");
-var jwt = require("jsonwebtoken");
-var config = require("../../config");
+const log = require("../../logging");
+const jwt = require("jsonwebtoken");
+const config = require("../../config");
 
 const VALID_DATAPOINT_UPLOAD_REQUEST = "Thanks for the data.";
 const VALID_DATAPOINT_UPDATE_REQUEST = "Datapoint was updated.";
@@ -40,7 +40,7 @@ function send(response, data) {
     // Respond with server error if data is invalid.
     return serverError(response, data);
   }
-  var statusCode = data.statusCode;
+  const statusCode = data.statusCode;
   data.success = 200 <= statusCode && statusCode <= 299;
   delete data.statusCode;
   return response.status(statusCode).json(data);

--- a/api/V1/signedUrl.js
+++ b/api/V1/signedUrl.js
@@ -45,16 +45,16 @@ module.exports = function(app, baseUrl) {
     baseUrl + "/signedUrl",
     [auth.signedUrl],
     middleware.requestWrapper(async (request, response) => {
-      var mimeType = request.jwtDecoded.mimeType || "";
-      var filename = request.jwtDecoded.filename || "file";
+      const mimeType = request.jwtDecoded.mimeType || "";
+      const filename = request.jwtDecoded.filename || "file";
 
-      var key = request.jwtDecoded.key;
+      const key = request.jwtDecoded.key;
       if (!key) {
         throw new ClientError("No key provided.");
       }
 
-      var s3 = modelsUtil.openS3();
-      var params = {
+      const s3 = modelsUtil.openS3();
+      const params = {
         Bucket: config.s3.bucket,
         Key: key
       };
@@ -76,14 +76,14 @@ module.exports = function(app, baseUrl) {
           return response.end(null, "binary");
         }
 
-        var range = request.headers.range;
-        var positions = range.replace(/bytes=/, "").split("-");
-        var start = parseInt(positions[0], 10);
-        var total = data.Body.length;
-        var end = positions[1] ? parseInt(positions[1], 10) : total - 1;
-        var chunksize = end - start + 1;
+        const range = request.headers.range;
+        const positions = range.replace(/bytes=/, "").split("-");
+        const start = parseInt(positions[0], 10);
+        const total = data.Body.length;
+        const end = positions[1] ? parseInt(positions[1], 10) : total - 1;
+        const chunksize = end - start + 1;
 
-        var headers = {
+        const headers = {
           "Content-Range": "bytes " + start + "-" + end + "/" + total,
           "Content-Length": chunksize,
           "Accept-Ranges": "bytes",
@@ -92,8 +92,8 @@ module.exports = function(app, baseUrl) {
 
         response.writeHead(206, headers);
 
-        var bufStream = new stream.PassThrough();
-        var b2 = data.Body.slice(start, end + 1);
+        const bufStream = new stream.PassThrough();
+        const b2 = data.Body.slice(start, end + 1);
         bufStream.end(b2);
         bufStream.pipe(response);
       });

--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -26,15 +26,15 @@ const modelsUtil = require("../../models/util/util");
 
 function multipartUpload(buildRecord) {
   return (request, response) => {
-    var key = moment().format("YYYY/MM/DD/") + uuidv4();
-    var data;
-    var filename;
-    var upload;
+    const key = moment().format("YYYY/MM/DD/") + uuidv4();
+    let data;
+    let filename;
+    let upload;
 
     // Note regarding multiparty: there are no guarantees about the
     // order that the field and part handlers will be called. You need
     // to formulate the response to the client in the close handler.
-    var form = new multiparty.Form();
+    const form = new multiparty.Form();
 
     // Handle the "data" field.
     form.on("field", (name, value) => {
@@ -92,10 +92,10 @@ function multipartUpload(buildRecord) {
         return;
       }
 
-      var dbRecord;
+      let dbRecord;
       try {
         // Wait for the upload to complete.
-        var uploadResult = await upload;
+        const uploadResult = await upload;
         if (uploadResult instanceof Error) {
           responseUtil.serverError(response, uploadResult);
           return;

--- a/api/fileProcessing/index.js
+++ b/api/fileProcessing/index.js
@@ -7,7 +7,7 @@ const recordingUtil = require("../V1/recordingUtil");
 const responseUtil = require("../V1/responseUtil");
 
 module.exports = function(app) {
-  var apiUrl = "/api/fileProcessing";
+  const apiUrl = "/api/fileProcessing";
 
   /**
    * @api {get} /api/fileProcessing Get a new file processing job
@@ -19,9 +19,9 @@ module.exports = function(app) {
    */
   app.get(apiUrl, async (request, response) => {
     log.info(request.method + " Request: " + request.url);
-    var type = request.query.type;
-    var state = request.query.state;
-    var recording = await models.Recording.getOneForProcessing(type, state);
+    const type = request.query.type;
+    const state = request.query.state;
+    const recording = await models.Recording.getOneForProcessing(type, state);
     if (recording == null) {
       log.debug("No file to be processed.");
       return response.status(204).json();
@@ -45,15 +45,15 @@ module.exports = function(app) {
    * @apiParam {String} [newProcessedFileKey] LeoFS Key of the new file.
    */
   app.put(apiUrl, async (request, response) => {
-    var id = parseInt(request.body.id);
-    var jobKey = request.body.jobKey;
-    var success = middleware.parseBool(request.body.success);
-    var result = request.body.result;
-    var complete = middleware.parseBool(request.body.complete);
-    var newProcessedFileKey = request.body.newProcessedFileKey;
+    const id = parseInt(request.body.id);
+    const jobKey = request.body.jobKey;
+    const success = middleware.parseBool(request.body.success);
+    let result = request.body.result;
+    const complete = middleware.parseBool(request.body.complete);
+    const newProcessedFileKey = request.body.newProcessedFileKey;
 
     // Validate request.
-    var errorMessages = [];
+    const errorMessages = [];
     if (isNaN(id)) {
       errorMessages.push("'id' field needs to be a number.");
     }
@@ -77,7 +77,7 @@ module.exports = function(app) {
       });
     }
 
-    var recording = await models.Recording.findOne({ where: { id: id } });
+    const recording = await models.Recording.findOne({ where: { id: id } });
 
     // Check that jobKey is correct.
     if (jobKey != recording.get("jobKey")) {
@@ -87,8 +87,8 @@ module.exports = function(app) {
     }
 
     if (success) {
-      var jobs = models.Recording.processingStates[recording.type];
-      var nextJob = jobs[jobs.indexOf(recording.processingState) + 1];
+      const jobs = models.Recording.processingStates[recording.type];
+      const nextJob = jobs[jobs.indexOf(recording.processingState) + 1];
       recording.set("processingState", nextJob);
       recording.set("fileKey", newProcessedFileKey);
       log.info("Complete is " + complete);
@@ -335,7 +335,7 @@ module.exports = function(app) {
     apiUrl + "/algorithm",
     [middleware.parseJSON("algorithm", body)],
     middleware.requestWrapper(async (request, response) => {
-      var algorithm = await models.DetailSnapshot.getOrCreateMatching(
+      const algorithm = await models.DetailSnapshot.getOrCreateMatching(
         "algorithm",
         request.body.algorithm
       );

--- a/api/middleware.js
+++ b/api/middleware.js
@@ -161,7 +161,7 @@ const parseJSON = function(field, checkFunc) {
 
 const parseArray = function(field, checkFunc) {
   return checkFunc(field).custom((value, { req, location, path }) => {
-    var arr;
+    let arr;
     try {
       arr = JSON.parse(value);
     } catch (e) {
@@ -187,7 +187,7 @@ const parseBool = function(value) {
 };
 
 const requestWrapper = fn => (request, response, next) => {
-  var logMessage = format("%s %s", request.method, request.url);
+  let logMessage = format("%s %s", request.method, request.url);
   if (request.user) {
     logMessage = format(
       "%s (user: %s)",

--- a/config.js
+++ b/config.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 
 // Set some default configuration
-var server = {
+const server = {
   loggerLevel: "info"
 };
 
@@ -11,7 +11,7 @@ function loadConfig(configPath) {
   checkConfigFileExists(configPath);
 
   const config = require(configPath);
-  for (var key in config) {
+  for (const key in config) {
     exports[key] = config[key];
   }
 

--- a/config/app_TEMPLATE.js
+++ b/config/app_TEMPLATE.js
@@ -1,6 +1,6 @@
 // Config instructions: Fill out required fields and save as 'config.js'
 
-var server = {
+const server = {
   // General server settings
   passportSecret: "random string", // REQUIRED, String. Random string used for passport module for encrypting JWT.
   loggerLevel: "debug", // REQUIRED, one of ('debug', 'warning', 'info', 'error')
@@ -10,12 +10,12 @@ var server = {
   }
 };
 
-var fileProcessing = {
+const fileProcessing = {
   // File processing API settings (runs on different port)
   port: 2002
 };
 
-var database = {
+const database = {
   username: "root",
   password: "",
   database: "cacophony",
@@ -23,7 +23,7 @@ var database = {
   dialect: "postgres"
 };
 
-var s3 = {
+const s3 = {
   // Used for storing audio & video recordings.
   publicKey: "", // REQUIRED, String:
   privateKey: "", // REQUIRED, String

--- a/hash-passwd.js
+++ b/hash-passwd.js
@@ -4,13 +4,13 @@ given password. It's useful when manually updating a user's password
 in the database.
 */
 
-var bcrypt = require("bcrypt");
+const bcrypt = require("bcrypt");
 
 if (process.argv.length != 3) {
   console.log("usage: node hash-passwd.js <password>");
   process.exit(1);
 }
-var hash = bcrypt.hashSync(process.argv[2], 10);
+const hash = bcrypt.hashSync(process.argv[2], 10);
 console.log(hash);
 console.log(
   `UPDATE "Users" SET password = '` + hash + `' WHERE username = '<username>'`

--- a/logging.js
+++ b/logging.js
@@ -1,8 +1,8 @@
-var config = require("./config");
-var winston = require("winston");
-var expressWinston = require("express-winston");
+const config = require("./config");
+const winston = require("winston");
+const expressWinston = require("express-winston");
 
-var consoleTransport = new winston.transports.Console({
+const consoleTransport = new winston.transports.Console({
   name: "console",
   level: config.server.loggerLevel,
   colorize: true,
@@ -10,7 +10,7 @@ var consoleTransport = new winston.transports.Console({
   humanReadableUnhandledException: true
 });
 
-var logger = new winston.Logger({
+const logger = new winston.Logger({
   transports: [consoleTransport]
 });
 

--- a/migrations/20170309221804-init.js
+++ b/migrations/20170309221804-init.js
@@ -1,4 +1,4 @@
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: function(queryInterface, Sequelize) {

--- a/migrations/20170322030146-Adding-ir-thermal-relations..js
+++ b/migrations/20170322030146-Adding-ir-thermal-relations..js
@@ -1,4 +1,4 @@
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: function(queryInterface) {

--- a/migrations/20170602051712-add-tag-model-migration.js
+++ b/migrations/20170602051712-add-tag-model-migration.js
@@ -1,5 +1,5 @@
 "use strict";
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: function(queryInterface, Sequelize) {

--- a/migrations/20170915030709-add-general-recording-table-migration.js
+++ b/migrations/20170915030709-add-general-recording-table-migration.js
@@ -1,5 +1,5 @@
 "use strict";
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: async function(queryInterface, Sequelize) {

--- a/migrations/20171122123700-add-deviceusers.js
+++ b/migrations/20171122123700-add-deviceusers.js
@@ -1,4 +1,4 @@
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: async function(queryInterface, Sequelize) {

--- a/migrations/20180330045054-create-events.js
+++ b/migrations/20180330045054-create-events.js
@@ -1,5 +1,5 @@
 "use strict";
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: async function(queryInterface, Sequelize) {

--- a/migrations/20180415192838-create-file.js
+++ b/migrations/20180415192838-create-file.js
@@ -1,5 +1,5 @@
 "use strict";
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: async function(queryInterface, Sequelize) {

--- a/migrations/20180427021359-create-schedule.js
+++ b/migrations/20180427021359-create-schedule.js
@@ -1,5 +1,5 @@
 "use strict";
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: async function(queryInterface, Sequelize) {

--- a/migrations/20180820054342-remove-tags-audio-relation.js
+++ b/migrations/20180820054342-remove-tags-audio-relation.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: async function(queryInterface) {

--- a/migrations/20190207213836-create-tracks.js
+++ b/migrations/20190207213836-create-tracks.js
@@ -1,5 +1,5 @@
 "use strict";
-var util = require("../models/util/util");
+const util = require("../models/util/util");
 
 module.exports = {
   up: async function(queryInterface, Sequelize) {

--- a/models/DetailSnapshot.js
+++ b/models/DetailSnapshot.js
@@ -16,20 +16,20 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var Sequelize = require("sequelize");
+const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
 
 module.exports = function(sequelize, DataTypes) {
-  var name = "DetailSnapshot";
+  const name = "DetailSnapshot";
 
-  var attributes = {
+  const attributes = {
     type: DataTypes.STRING,
     details: DataTypes.JSONB
   };
 
-  var options = {};
+  const options = {};
 
-  var DetailSnapshot = sequelize.define(name, attributes, options);
+  const DetailSnapshot = sequelize.define(name, attributes, options);
 
   //---------------
   // CLASS METHODS

--- a/models/Device.js
+++ b/models/Device.js
@@ -16,15 +16,15 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var bcrypt = require("bcrypt");
-var Sequelize = require("sequelize");
+const bcrypt = require("bcrypt");
+const Sequelize = require("sequelize");
 const { AuthorizationError } = require("../api/customErrors");
 const Op = Sequelize.Op;
 
 module.exports = function(sequelize, DataTypes) {
-  var name = "Device";
+  const name = "Device";
 
-  var attributes = {
+  const attributes = {
     devicename: {
       type: DataTypes.STRING,
       unique: true
@@ -51,13 +51,13 @@ module.exports = function(sequelize, DataTypes) {
     }
   };
 
-  var options = {
+  const options = {
     hooks: {
       afterValidate: afterValidate
     }
   };
 
-  var Device = sequelize.define(name, attributes, options);
+  const Device = sequelize.define(name, attributes, options);
 
   //---------------
   // CLASS METHODS
@@ -87,7 +87,7 @@ module.exports = function(sequelize, DataTypes) {
     }
 
     // Get association if already there and update it.
-    var deviceUser = await models.DeviceUsers.findOne({
+    const deviceUser = await models.DeviceUsers.findOne({
       where: {
         DeviceId: device.id,
         UserId: userToAdd.id
@@ -124,7 +124,7 @@ module.exports = function(sequelize, DataTypes) {
         UserId: userToRemove.id
       }
     });
-    for (var i in deviceUsers) {
+    for (const i in deviceUsers) {
       await deviceUsers[i].destroy();
     }
     return true;
@@ -145,8 +145,8 @@ module.exports = function(sequelize, DataTypes) {
       });
     }
 
-    var deviceIds = await user.getDeviceIds();
-    var userGroupIds = await user.getGroupsIds();
+    const deviceIds = await user.getDeviceIds();
+    const userGroupIds = await user.getGroupsIds();
 
     const usersDevice = {
       [Op.or]: [
@@ -183,7 +183,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   Device.freeDevicename = async function(devicename) {
-    var device = await this.findOne({ where: { devicename: devicename } });
+    const device = await this.findOne({ where: { devicename: devicename } });
     if (device != null) {
       throw new Error("device name in use");
     }
@@ -223,7 +223,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   Device.prototype.comparePassword = function(password) {
-    var device = this;
+    const device = this;
     return new Promise(function(resolve, reject) {
       bcrypt.compare(password, device.password, function(err, isMatch) {
         if (err) {

--- a/models/DeviceUsers.js
+++ b/models/DeviceUsers.js
@@ -17,16 +17,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 module.exports = function(sequelize, DataTypes) {
-  var name = "DeviceUsers";
+  const name = "DeviceUsers";
 
-  var attributes = {
+  const attributes = {
     admin: {
       type: DataTypes.BOOLEAN,
       defaultValue: false
     }
   };
 
-  var DeviceUsers = sequelize.define(name, attributes);
+  const DeviceUsers = sequelize.define(name, attributes);
 
   //---------------
   // CLASS METHODS
@@ -35,7 +35,7 @@ module.exports = function(sequelize, DataTypes) {
   DeviceUsers.addAssociations = function() {};
 
   DeviceUsers.isAdmin = async function(deviceId, userId) {
-    var deviceUser = await this.findOne({
+    const deviceUser = await this.findOne({
       where: {
         DeviceId: deviceId,
         UserId: userId,

--- a/models/Event.js
+++ b/models/Event.js
@@ -18,22 +18,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 "use strict";
 
-var Sequelize = require("sequelize");
+const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
 
 module.exports = function(sequelize, DataTypes) {
-  var name = "Event";
+  const name = "Event";
 
-  var attributes = {
+  const attributes = {
     dateTime: DataTypes.DATE
   };
 
-  var Event = sequelize.define(name, attributes);
+  const Event = sequelize.define(name, attributes);
 
   //---------------
   // CLASS METHODS
   //---------------
-  var models = sequelize.models;
+  const models = sequelize.models;
 
   Event.addAssociations = function(models) {
     models.Event.belongsTo(models.DetailSnapshot, {

--- a/models/File.js
+++ b/models/File.js
@@ -17,24 +17,29 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 "use strict";
+const _ = require("lodash");
 const { AuthorizationError } = require("../api/customErrors");
 module.exports = function(sequelize, DataTypes) {
-  var name = "File";
+  const name = "File";
 
-  var attributes = {
+  const attributes = {
     type: DataTypes.STRING,
     fileKey: DataTypes.STRING,
     fileSize: DataTypes.STRING,
     details: DataTypes.JSONB
   };
 
-  var File = sequelize.define(name, attributes);
+  const File = sequelize.define(name, attributes);
 
   File.apiSettableFields = ["type", "details"];
 
   //---------------
   // CLASS METHODS
   //---------------
+
+  File.buildSafely = function(fields) {
+    return File.build(_.pick(fields, File.apiSettableFields));
+  };
 
   File.addAssociations = function(models) {
     models.File.belongsTo(models.User);

--- a/models/File.js
+++ b/models/File.js
@@ -54,7 +54,7 @@ module.exports = function(sequelize, DataTypes) {
       order = [["id", "DESC"]];
     }
 
-    var q = {
+    const q = {
       where: where,
       order: order,
       attributes: { exclude: ["updatedAt", "fileKey"] },

--- a/models/Group.js
+++ b/models/Group.js
@@ -18,22 +18,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 const { AuthorizationError } = require("../api/customErrors");
 module.exports = function(sequelize, DataTypes) {
-  var name = "Group";
+  const name = "Group";
 
-  var attributes = {
+  const attributes = {
     groupname: {
       type: DataTypes.STRING
     }
   };
 
-  var Group = sequelize.define(name, attributes);
+  const Group = sequelize.define(name, attributes);
 
   Group.apiSettableFields = [];
 
   //---------------
   // Class methods
   //---------------
-  var models = sequelize.models;
+  const models = sequelize.models;
 
   Group.addAssociations = function(models) {
     models.Group.hasMany(models.Device);
@@ -53,7 +53,7 @@ module.exports = function(sequelize, DataTypes) {
     }
 
     // Get association if already there and update it.
-    var groupUser = await models.GroupUsers.findOne({
+    const groupUser = await models.GroupUsers.findOne({
       where: {
         GroupId: group.id,
         UserId: userToAdd.id
@@ -95,7 +95,7 @@ module.exports = function(sequelize, DataTypes) {
    * that the user belongs if user does not have global read/write permission.
    */
   Group.query = async function(where, user) {
-    var userWhere = { id: user.id };
+    let userWhere = { id: user.id };
     if (user.hasGlobalRead()) {
       userWhere = null;
     }
@@ -168,7 +168,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   Group.freeGroupname = async function(name) {
-    var group = await this.findOne({ where: { groupname: name } });
+    const group = await this.findOne({ where: { groupname: name } });
     if (group != null) {
       throw new Error("groupname in use");
     }
@@ -176,7 +176,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   Group.getIdFromName = function(name) {
-    var Group = this;
+    const Group = this;
     return new Promise(function(resolve) {
       Group.findOne({ where: { groupname: name } }).then(function(group) {
         if (!group) {

--- a/models/GroupUsers.js
+++ b/models/GroupUsers.js
@@ -17,16 +17,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 module.exports = function(sequelize, DataTypes) {
-  var name = "GroupUsers";
+  const name = "GroupUsers";
 
-  var attributes = {
+  const attributes = {
     admin: {
       type: DataTypes.BOOLEAN,
       defaultValue: false
     }
   };
 
-  var GroupUsers = sequelize.define(name, attributes);
+  const GroupUsers = sequelize.define(name, attributes);
 
   //---------------
   // CLASS METHODS
@@ -36,7 +36,7 @@ module.exports = function(sequelize, DataTypes) {
    * Checks if a user is a admin of a group.
    */
   GroupUsers.isAdmin = async function(groupId, userId) {
-    var groupUsers = await this.findOne({
+    const groupUsers = await this.findOne({
       where: {
         GroupId: groupId,
         UserId: userId,

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -131,7 +131,7 @@ module.exports = function(sequelize, DataTypes) {
           lock: t.LOCK.UPDATE,
           transaction: t
         }).then(async function(recording) {
-          var date = new Date();
+          const date = new Date();
           recording.set(
             {
               jobKey: uuidv4(),
@@ -190,7 +190,7 @@ module.exports = function(sequelize, DataTypes) {
       ];
     }
 
-    var q = {
+    const q = {
       where: {
         [Op.and]: [
           where, // User query
@@ -238,7 +238,7 @@ module.exports = function(sequelize, DataTypes) {
       attributes: Recording.queryGetAttributes
     };
 
-    var queryResponse = await this.findAndCountAll(q);
+    const queryResponse = await this.findAndCountAll(q);
 
     filterOptions = makeFilterOptions(user, filterOptions);
     queryResponse.rows.map(rec => rec.filterData(filterOptions));
@@ -246,7 +246,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   // local
-  var handleTagMode = (tagMode, tagWhatsIn) => {
+  const handleTagMode = (tagMode, tagWhatsIn) => {
     const tagWhats = tagWhatsIn && tagWhatsIn.length > 0 ? tagWhatsIn : null;
     if (!tagMode) {
       tagMode = tagWhats ? "tagged" : "any";
@@ -290,19 +290,20 @@ module.exports = function(sequelize, DataTypes) {
       case "cool":
       case "missed track":
       case "multiple animals":
-      case "trapped in trap":
-        var sqlQuery =
+      case "trapped in trap": {
+        let sqlQuery =
           "(EXISTS (" + recordingTaggedWith([tagMode], null) + "))";
         if (tagWhats) {
           sqlQuery = sqlQuery + " AND " + tagOfType(tagWhats, null);
         }
         return sqlQuery;
+      }
       default:
         throw `invalid tag mode: ${tagMode}`;
     }
   };
 
-  var tagOfType = (tagWhats, tagTypeSql) => {
+  const tagOfType = (tagWhats, tagTypeSql) => {
     return (
       "(EXISTS (" +
       recordingTaggedWith(tagWhats, tagTypeSql) +
@@ -312,7 +313,7 @@ module.exports = function(sequelize, DataTypes) {
     );
   };
 
-  var notTagOfType = (tagWhats, tagTypeSql) => {
+  const notTagOfType = (tagWhats, tagTypeSql) => {
     return (
       "NOT EXISTS (" +
       recordingTaggedWith(tagWhats, tagTypeSql) +
@@ -322,7 +323,7 @@ module.exports = function(sequelize, DataTypes) {
     );
   };
 
-  var recordingTaggedWith = (tags, tagTypeSql) => {
+  const recordingTaggedWith = (tags, tagTypeSql) => {
     let sql =
       'SELECT "Recording"."id" FROM "Tags" WHERE  "Tags"."RecordingId" = "Recording".id';
     if (tags) {
@@ -334,7 +335,7 @@ module.exports = function(sequelize, DataTypes) {
     return sql;
   };
 
-  var trackTaggedWith = (tags, tagTypeSql) => {
+  const trackTaggedWith = (tags, tagTypeSql) => {
     let sql =
       'SELECT "Recording"."id" FROM "Tracks" INNER JOIN "TrackTags" AS "Tags" ON "Tracks"."id" = "Tags"."TrackId" ' +
       'WHERE "Tracks"."RecordingId" = "Recording".id AND "Tracks"."archivedAt" IS NULL';
@@ -348,14 +349,14 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   // local
-  var selectByTagWhat = (tags, whatName, usesDetail) => {
+  const selectByTagWhat = (tags, whatName, usesDetail) => {
     if (!tags || tags.length === 0) {
       return null;
     }
 
-    var parts = [];
-    for (var i = 0; i < tags.length; i++) {
-      var tag = tags[i];
+    const parts = [];
+    for (let i = 0; i < tags.length; i++) {
+      const tag = tags[i];
       if (tag == "interesting") {
         if (usesDetail) {
           parts.push(
@@ -459,7 +460,7 @@ module.exports = function(sequelize, DataTypes) {
    * Updates a single recording if the user has permission to do so.
    */
   Recording.updateOne = async function(user, id, updates) {
-    for (var key in updates) {
+    for (const key in updates) {
       if (apiUpdatableFields.indexOf(key) == -1) {
         return false;
       }
@@ -474,12 +475,12 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   // local
-  var recordingsFor = async function(user) {
+  const recordingsFor = async function(user) {
     if (user.hasGlobalRead()) {
       return null;
     }
-    var deviceIds = await user.getDeviceIds();
-    var groupIds = await user.getGroupsIds();
+    const deviceIds = await user.getDeviceIds();
+    const groupIds = await user.getGroupsIds();
     return {
       [Op.or]: [
         {
@@ -759,7 +760,7 @@ module.exports = function(sequelize, DataTypes) {
   ];
 
   // local
-  var apiUpdatableFields = ["location", "comment", "additionalMetadata"];
+  const apiUpdatableFields = ["location", "comment", "additionalMetadata"];
 
   Recording.processingStates = {
     thermalRaw: ["getMetadata", "toMp4", "FINISHED"],

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -16,21 +16,22 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var mime = require("mime");
-var moment = require("moment-timezone");
-var Sequelize = require("sequelize");
+const mime = require("mime");
+const moment = require("moment-timezone");
+const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
 const assert = require("assert");
 const uuidv4 = require("uuid/v4");
 
-var util = require("./util/util");
-var validation = require("./util/validation");
+const util = require("./util/util");
+const validation = require("./util/validation");
+const _ = require("lodash");
 const { AuthorizationError } = require("../api/customErrors");
 
 module.exports = function(sequelize, DataTypes) {
-  var name = "Recording";
+  const name = "Recording";
 
-  var attributes = {
+  const attributes = {
     // recording metadata.
     type: DataTypes.STRING,
     duration: DataTypes.INTEGER,
@@ -73,12 +74,16 @@ module.exports = function(sequelize, DataTypes) {
     airplaneModeOn: DataTypes.BOOLEAN
   };
 
-  var Recording = sequelize.define(name, attributes);
+  const Recording = sequelize.define(name, attributes);
 
   //---------------
   // CLASS METHODS
   //---------------
-  var models = sequelize.models;
+  const models = sequelize.models;
+
+  Recording.buildSafely = function(fields) {
+    return Recording.build(_.pick(fields, Recording.apiSettableFields));
+  };
 
   Recording.Perms = Object.freeze({
     DELETE: "delete",

--- a/models/Schedule.js
+++ b/models/Schedule.js
@@ -17,18 +17,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 "use strict";
-module.exports = function(sequelize, DataTypes) {
-  var name = "Schedule";
+const _ = require("lodash");
 
-  var attributes = {
+module.exports = function(sequelize, DataTypes) {
+  const name = "Schedule";
+
+  const attributes = {
     schedule: DataTypes.JSONB
   };
 
-  var Schedule = sequelize.define(name, attributes);
+  const Schedule = sequelize.define(name, attributes);
 
   //---------------
   // CLASS METHODS
   //---------------
+
+  Schedule.buildSafely = function(fields) {
+    return Schedule.build(_.pick(fields, ["schedule"]));
+  };
 
   Schedule.addAssociations = function(models) {
     models.Schedule.belongsTo(models.User);

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -79,7 +79,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   Tag.deleteFromId = async function(id, user) {
-    var tag = await this.findOne({ where: { id: id } });
+    const tag = await this.findOne({ where: { id: id } });
     if (tag == null) {
       return true;
     }

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -16,12 +16,13 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var util = require("./util/util");
+const util = require("./util/util");
+const _ = require("lodash");
 
 module.exports = function(sequelize, DataTypes) {
-  var name = "Tag";
+  const name = "Tag";
 
-  var attributes = {
+  const attributes = {
     what: {
       type: DataTypes.STRING
     },
@@ -53,12 +54,16 @@ module.exports = function(sequelize, DataTypes) {
     }
   };
 
-  var Tag = sequelize.define(name, attributes);
+  const Tag = sequelize.define(name, attributes);
 
   //---------------
   // CLASS METHODS
   //---------------
   const Recording = sequelize.models.Recording;
+
+  Tag.buildSafely = function(fields) {
+    return Tag.build(_.pick(fields, Tag.apiSettableFields));
+  };
 
   Tag.addAssociations = function(models) {
     models.Tag.belongsTo(models.User, { as: "tagger" });

--- a/models/Track.js
+++ b/models/Track.js
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 module.exports = function(sequelize, DataTypes) {
-  var Track = sequelize.define("Track", {
+  const Track = sequelize.define("Track", {
     data: DataTypes.JSONB,
     archivedAt: DataTypes.DATE
   });
@@ -34,7 +34,7 @@ module.exports = function(sequelize, DataTypes) {
     models.Track.hasMany(models.TrackTag);
   };
 
-  var models = sequelize.models;
+  const models = sequelize.models;
 
   Track.apiSettableFields = Object.freeze(["algorithm", "data", "archivedAt"]);
 

--- a/models/TrackTag.js
+++ b/models/TrackTag.js
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 module.exports = function(sequelize, DataTypes) {
-  var TrackTag = sequelize.define("TrackTag", {
+  const TrackTag = sequelize.define("TrackTag", {
     what: DataTypes.STRING,
     confidence: DataTypes.FLOAT,
     automatic: DataTypes.BOOLEAN,

--- a/models/User.js
+++ b/models/User.js
@@ -16,8 +16,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var bcrypt = require("bcrypt");
-var Sequelize = require("sequelize");
+const bcrypt = require("bcrypt");
+const Sequelize = require("sequelize");
 const { AuthorizationError } = require("../api/customErrors");
 const log = require("../logging");
 const Op = Sequelize.Op;
@@ -32,9 +32,9 @@ const PERMISSIONS = Object.freeze([
 ]);
 
 module.exports = function(sequelize, DataTypes) {
-  var name = "User";
+  const name = "User";
 
-  var attributes = {
+  const attributes = {
     username: {
       type: DataTypes.STRING,
       unique: true
@@ -61,7 +61,7 @@ module.exports = function(sequelize, DataTypes) {
     }
   };
 
-  var options = {
+  const options = {
     hooks: {
       beforeValidate: beforeValidate,
       beforeCreate: beforeModify,
@@ -71,7 +71,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   // Define table
-  var User = sequelize.define(name, attributes, options);
+  const User = sequelize.define(name, attributes, options);
 
   User.publicFields = Object.freeze(["id", "username"]);
 
@@ -108,7 +108,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   User.freeUsername = async function(username) {
-    var user = await this.findOne({ where: { username: username } });
+    const user = await this.findOne({ where: { username: username } });
     if (user != null) {
       throw new Error("Username in use");
     }
@@ -126,7 +126,7 @@ module.exports = function(sequelize, DataTypes) {
       //Ignore email from this user
       where.id = { [Op.not]: userId };
     }
-    var user = await this.findOne({ where: where });
+    const user = await this.findOne({ where: where });
     if (user) {
       throw new Error("Email in use");
     }
@@ -156,9 +156,9 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   User.prototype.getGroupDeviceIds = async function() {
-    var groupIds = await this.getGroupsIds();
+    const groupIds = await this.getGroupsIds();
     if (groupIds.length > 0) {
-      var devices = await models.Device.findAll({
+      const devices = await models.Device.findAll({
         where: { GroupId: { [Op.in]: groupIds } },
         attributes: ["id"]
       });
@@ -173,7 +173,7 @@ module.exports = function(sequelize, DataTypes) {
       return null;
     }
 
-    var allDeviceIds = await this.getAllDeviceIds();
+    const allDeviceIds = await this.getAllDeviceIds();
     return { DeviceId: { [Op.in]: allDeviceIds } };
   };
 
@@ -185,7 +185,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   User.prototype.getDataValues = function() {
-    var user = this;
+    const user = this;
     return new Promise(function(resolve) {
       user.getGroups().then(function(groups) {
         resolve({
@@ -227,7 +227,7 @@ module.exports = function(sequelize, DataTypes) {
 
   User.prototype.checkUserControlsDevices = async function(deviceIds) {
     if (!this.hasGlobalWrite()) {
-      var usersDevices = await this.getAllDeviceIds();
+      const usersDevices = await this.getAllDeviceIds();
 
       deviceIds.forEach(deviceId => {
         if (!usersDevices.includes(deviceId)) {
@@ -252,7 +252,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   User.prototype.comparePassword = function(password) {
-    var user = this;
+    const user = this;
     return new Promise(function(resolve, reject) {
       bcrypt.compare(password, user.password, function(err, isMatch) {
         if (err) {

--- a/models/index.js
+++ b/models/index.js
@@ -78,7 +78,7 @@ fs.readdirSync(__dirname)
     );
   })
   .forEach(function(file) {
-    var model = sequelize["import"](path.join(__dirname, file));
+    const model = sequelize["import"](path.join(__dirname, file));
     db[model.name] = model;
   });
 

--- a/models/util/util.js
+++ b/models/util/util.js
@@ -16,17 +16,17 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-var AWS = require("aws-sdk");
-var log = require("../../logging");
-var fs = require("fs");
-var mime = require("mime");
-var config = require("../../config");
-var Sequelize = require("sequelize");
+const AWS = require("aws-sdk");
+const log = require("../../logging");
+const fs = require("fs");
+const mime = require("mime");
+const config = require("../../config");
+const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
 
 function findAllWithUser(model, user, queryParams) {
   return new Promise(function(resolve) {
-    var models = require("../");
+    const models = require("../");
     if (typeof queryParams.limit == "undefined") {
       queryParams.limit = 20;
     }
@@ -80,8 +80,8 @@ function getFileData(model, id, user) {
     findAllWithUser(model, user, { where: { id } })
       .then(function(result) {
         if (result.rows !== null && result.rows.length >= 1) {
-          var model = result.rows[0];
-          var fileData = {
+          const model = result.rows[0];
+          const fileData = {
             key: model.getDataValue("fileKey"),
             name: getFileName(model),
             mimeType: model.getDataValue("mimeType")
@@ -99,8 +99,8 @@ function getFileData(model, id, user) {
 }
 
 function getFileName(model) {
-  var fileName;
-  var dateStr = model.getDataValue("recordingDateTime");
+  let fileName;
+  const dateStr = model.getDataValue("recordingDateTime");
   if (dateStr) {
     fileName = new Date(dateStr)
       .toISOString()
@@ -110,7 +110,7 @@ function getFileName(model) {
     fileName = "file";
   }
 
-  var ext = mime.getExtension(model.getDataValue("mimeType") || "");
+  const ext = mime.getExtension(model.getDataValue("mimeType") || "");
   if (ext) {
     fileName = fileName + "." + ext;
   }
@@ -137,18 +137,18 @@ function migrationAddBelongsTo(queryInterface, childTable, parentTable, opts) {
     };
   }
 
-  var columnName = parentTable.substring(0, parentTable.length - 1) + "Id";
+  let columnName = parentTable.substring(0, parentTable.length - 1) + "Id";
   if (opts.name) {
     columnName = opts.name + "Id";
   }
   const constraintName = childTable + "_" + columnName + "_fkey";
 
-  var deleteBehaviour = "SET NULL";
+  let deleteBehaviour = "SET NULL";
   if (opts.cascade) {
     deleteBehaviour = "CASCADE";
   }
 
-  var columnNull = "";
+  let columnNull = "";
   if (opts.notNull) {
     columnNull = "NOT NULL";
   }
@@ -210,7 +210,7 @@ function migrationRemoveBelongsTo(
   parentTable,
   opts = {}
 ) {
-  var columnName = parentTable.substring(0, parentTable.length - 1) + "Id";
+  let columnName = parentTable.substring(0, parentTable.length - 1) + "Id";
   if (opts.name) {
     columnName = opts.name + "Id";
   }
@@ -220,10 +220,10 @@ function migrationRemoveBelongsTo(
 }
 
 function belongsToMany(queryInterface, viaTable, table1, table2) {
-  var columnName1 = table1.substring(0, table1.length - 1) + "Id";
-  var constraintName1 = viaTable + "_" + columnName1 + "_fkey";
-  var columnName2 = table2.substring(0, table2.length - 1) + "Id";
-  var constraintName2 = viaTable + "_" + columnName2 + "_fkey";
+  const columnName1 = table1.substring(0, table1.length - 1) + "Id";
+  const constraintName1 = viaTable + "_" + columnName1 + "_fkey";
+  const columnName2 = table2.substring(0, table2.length - 1) + "Id";
+  const constraintName2 = viaTable + "_" + columnName2 + "_fkey";
   console.log("Adding belongs to many columns.");
   return new Promise(function(resolve, reject) {
     Promise.all([
@@ -281,7 +281,7 @@ function addSerial(queryInterface, tableName) {
 }
 
 function getFromId(id, user, attributes) {
-  var modelClass = this;
+  const modelClass = this;
   return new Promise(resolve => {
     // Get just public models if no user was given
     if (!user) {
@@ -295,7 +295,7 @@ function getFromId(id, user, attributes) {
       .then(ids => {
         // Condition where you get a public recordin or a recording that you
         // have permission to view (in same group).
-        var condition = {
+        const condition = {
           where: {
             id: id,
             [Op.or]: [{ GroupId: { [Op.in]: ids } }, { public: true }]
@@ -315,8 +315,8 @@ function getFromId(id, user, attributes) {
  * to delete the file and modelInstance.
  */
 function deleteModelInstance(id, user) {
-  var modelClass = this;
-  var modelInstance = null;
+  const modelClass = this;
+  let modelInstance = null;
   return new Promise((resolve, reject) => {
     modelClass
       .getFromId(id, user, ["fileKey", "id"])
@@ -335,7 +335,7 @@ function deleteModelInstance(id, user) {
 }
 
 function userCanEdit(id, user) {
-  var modelClass = this;
+  const modelClass = this;
   return new Promise(resolve => {
     //models.User.where
     modelClass.getFromId(id, user, ["id"]).then(result => {
@@ -358,13 +358,15 @@ function openS3() {
 }
 
 function saveFile(file) {
-  var model = this;
+  const model = this;
   return new Promise(function(resolve, reject) {
     // Gets date object set to recordingDateTime field or now if field not set.
-    var date = new Date(model.getDataValue("recordingDateTime") || new Date());
+    const date = new Date(
+      model.getDataValue("recordingDateTime") || new Date()
+    );
 
     // Generate key for file using the date.
-    var key =
+    const key =
       date.getFullYear() +
       "/" +
       date.getMonth() +
@@ -379,9 +381,9 @@ function saveFile(file) {
         .substr(2);
 
     // Save file with key.
-    var s3 = openS3();
+    const s3 = openS3();
     fs.readFile(file.path, function(err, data) {
-      var params = {
+      const params = {
         Bucket: config.s3.bucket,
         Key: key,
         Body: data
@@ -409,8 +411,8 @@ function saveFile(file) {
 
 function deleteFile(fileKey) {
   return new Promise((resolve, reject) => {
-    var s3 = openS3();
-    var params = {
+    const s3 = openS3();
+    const params = {
       Bucket: config.s3.bucket,
       Key: fileKey
     };

--- a/models/util/validation.js
+++ b/models/util/validation.js
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Validate that input is a valid [latitude, longitude]
 function isLatLon(point) {
-  var val = point.coordinates;
+  const val = point.coordinates;
   if (
     val === null ||
     typeof val !== "object" ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -5892,6 +5892,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "install": "^0.12.1",
     "json-pointer": "^0.5.0",
     "jsonwebtoken": "^8.3.0",
+    "lodash": "^4.17.11",
     "mime": "^2.3",
     "moment": "^2.19.3",
     "moment-timezone": "^0.5.14",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "winston": "^1.0.1"
   },
   "devDependencies": {
-    "eslint": "^5.15.3"
+    "eslint": "^5.15.3",
+    "prettier": "1.18.2"
   },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",

--- a/passportConfig.js
+++ b/passportConfig.js
@@ -1,12 +1,12 @@
-var JwtStrategy = require("passport-jwt").Strategy;
-var ExtractJwt = require("passport-jwt").ExtractJwt;
-var AnonymousStrategy = require("passport-anonymous");
-var models = require("./models");
-var config = require("../../config");
+const JwtStrategy = require("passport-jwt").Strategy;
+const ExtractJwt = require("passport-jwt").ExtractJwt;
+const AnonymousStrategy = require("passport-anonymous");
+const models = require("./models");
+const config = require("../../config");
 
 module.exports = function(passport) {
   passport.use(new AnonymousStrategy());
-  var opts = {
+  const opts = {
     jwtFromRequest: getJWT,
     secretOrKey: config.server.passportSecret
   };

--- a/prune-objects.js
+++ b/prune-objects.js
@@ -42,9 +42,9 @@ async function allBucketKeys(s3, bucket) {
     Bucket: bucket
   };
 
-  var keys = new Set();
+  const keys = new Set();
   for (;;) {
-    var data = await s3.listObjects(params).promise();
+    const data = await s3.listObjects(params).promise();
 
     data.Contents.forEach(elem => {
       keys.add(elem.Key);
@@ -84,7 +84,7 @@ async function pgConnect() {
 }
 
 async function allDBKeys(client) {
-  var keys = new Set();
+  const keys = new Set();
   const res = await client.query(`
         select "fileKey" as fk, "rawFileKey" as rk from "Recordings"
         union

--- a/test/test_audio_device.py
+++ b/test/test_audio_device.py
@@ -13,3 +13,24 @@ class TestAudioDevice:
 
         print("And the audio recording can be downloaded by a user")
         user.can_download_correct_recording(recording)
+
+    def test_can_only_set_user_settable_fields(self, helper):
+        UNSETTABLE_FIELD = "fileKey"
+        UNSETTABLE_INPUT_VALUE = "test_value"
+
+        description = "If a new device 'Listener' signs up"
+        listener = helper.given_new_device(self, "Listener", description=description)
+
+        print("Then 'Listener' should able to log in")
+        helper.login_as_device(listener.devicename)
+
+        print("And 'Listener' should be able to upload an audio file even with disallowed metadata")
+        recording = listener.upload_audio_recording({UNSETTABLE_FIELD: UNSETTABLE_INPUT_VALUE})
+
+        user = helper.admin_user()
+
+        print("But when a user gets the metadata")
+        metadata = user.get_recording(recording)
+
+        print("It should not include the unsettable field")
+        assert metadata[UNSETTABLE_FIELD] != UNSETTABLE_INPUT_VALUE

--- a/test/testdevice.py
+++ b/test/testdevice.py
@@ -50,7 +50,7 @@ class TestDevice:
             "additionalMetadata": {"bar": "foo"},
         }
 
-    def upload_audio_recording(self):
+    def upload_audio_recording(self, extraProps={}):
         ts = _new_timestamp()
         props = {
             "recordingDateTime": ts.isoformat(),
@@ -64,6 +64,7 @@ class TestDevice:
             "version": "123",
             "additionalMetadata": {"foo": "bar"},
         }
+        props.update(extraProps)
         filename = "files/small.mp3"
         recording_id = self._deviceapi.upload_audio_recording(filename, props)
 


### PR DESCRIPTION
Note: Recommend viewing the changes on a per commit basis as the let/const change is very big. The other three changes are more significant and much smaller.

Fix #231 by defining "buildSafely" methods to replace standard build in the model objects. These methods just run the lodash filter then call the standard build method.
Added test for this for recordings that failed and now passes.

Fix #215 by adding description of the return type

Convert all vars to let/const

Update eslint to handle switch indentation as now done by prettier, moved intent back to error.
Update eslint to consider var an error, require let/const instead.
Added prettier as a dev dependency to make it easier to run the restyle locally to prevent the bot getting mad.