### PR TITLE
Make object pruning safer and run pruning daily

### DIFF
--- a/_release/cacophony-api-prune-objects
+++ b/_release/cacophony-api-prune-objects
@@ -1,0 +1,4 @@
+#
+# cron.d/cacophony-api-prune-objects
+#
+0 11 * * * root cd /srv/cacophony/api/ && node prune-objects.js --delete

--- a/_release/nfpm.yaml
+++ b/_release/nfpm.yaml
@@ -15,6 +15,7 @@ depends:
 files:
   "**/*": "/srv/cacophony/api/"
   "_release/cacophony-api.service": "/etc/systemd/system/cacophony-api.service"
+  "_release/cacophony-api-prune-objects": "/etc/cron.d/cacophony-api-prune-objects"
 
 config_files:
   "config/app_TEMPLATE.js": "/etc/cacophony/api.js"

--- a/api/V1/File.js
+++ b/api/V1/File.js
@@ -48,7 +48,7 @@ module.exports = (app, baseUrl) => {
     apiUrl,
     [auth.authenticateUser],
     middleware.requestWrapper(
-      util.multipartUpload((request, data, key) => {
+      util.multipartUpload("f", (request, data, key) => {
         const dbRecord = models.File.buildSafely(data);
         dbRecord.UserId = request.user.id;
         dbRecord.fileKey = key;

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -25,7 +25,7 @@ const responseUtil = require("./responseUtil");
 const util = require("./util");
 
 function makeUploadHandler(mungeData) {
-  return util.multipartUpload((request, data, key) => {
+  return util.multipartUpload("raw", (request, data, key) => {
     if (mungeData) {
       data = mungeData(data);
     }

--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -24,9 +24,9 @@ const responseUtil = require("./responseUtil");
 const config = require("../../config");
 const modelsUtil = require("../../models/util/util");
 
-function multipartUpload(buildRecord) {
+function multipartUpload(keyPrefix, buildRecord) {
   return (request, response) => {
-    const key = moment().format("YYYY/MM/DD/") + uuidv4();
+    const key = keyPrefix + "/" + moment().format("YYYY/MM/DD/") + uuidv4();
     let data;
     let filename;
     let upload;


### PR DESCRIPTION
* Use a type prefix for the object keys: This allows prune-objects to more safely remove unused keys by only operating on these prefixes. These prefixes could also help make management of the object store easier.
* prune-objects now only acts on specific object key prefixes 
* Run prune-objects daily via cron