### PR TITLE
Send prune-objects output to syslog

### DIFF
--- a/_release/cacophony-api-prune-objects
+++ b/_release/cacophony-api-prune-objects
@@ -1,4 +1,4 @@
 #
 # cron.d/cacophony-api-prune-objects
 #
-0 11 * * * root cd /srv/cacophony/api/ && node prune-objects.js --delete
+0 11 * * * root (cd /srv/cacophony/api/ && node prune-objects.js --delete) 2>&1 | logger --tag prune-objects


### PR DESCRIPTION
This adds timestamps and is preferable to receiving a daily email.