### PR TITLE
Add run --no-cache option and fix mc again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get install -y tzdata
 RUN echo "Pacific/Auckland" > /etc/timezone
 RUN ln -sf /usr/share/zoneinfo/Pacific/Auckland /etc/localtime
 
-RUN apt-get -y install curl wget sudo make build-essential g++
+RUN apt-get -y install curl sudo make build-essential g++
 
 RUN apt-get -y install postgis postgresql-server-dev-10
 RUN echo "listen_addresses = '*'" >> /etc/postgresql/10/main/postgresql.conf
@@ -22,11 +22,11 @@ RUN apt-get install -y nodejs
 RUN npm install -g nodemon
 
 # https://minio.io/downloads.html#download-server-linux-x64
-RUN wget --no-verbose https://dl.minio.io/server/minio/release/linux-amd64/minio
+RUN curl --location --fail --silent --show-error --remote-name https://dl.minio.io/server/minio/release/linux-amd64/minio
 RUN chmod +x minio
 
 # https://docs.minio.io/docs/minio-client-complete-guide
-RUN wget --no-verbose https://dl.minio.io/client/mc/release/linux-amd64/mc
+RUN curl --location --fail --silent --show-error https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2019-07-11T19-31-28Z > mc
 RUN chmod +x mc
 
 COPY docker-entrypoint.sh /

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,8 +14,8 @@ sudo -i -u postgres psql -c "CREATE DATABASE cacophonytest WITH OWNER test;"
 sudo -i -u postgres psql cacophonytest -c "CREATE EXTENSION postgis"
 
 echo "---- Setting up Minio ----"
-./mc --no-autocompletion config host add myminio http://127.0.0.1:9001 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
-./mc --no-autocompletion mb myminio/cacophony
+./mc config host add myminio http://127.0.0.1:9001 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+./mc mb myminio/cacophony
 
 echo "mc done"
 

--- a/run
+++ b/run
@@ -24,23 +24,28 @@ parser.add_argument(
     action="store_true",
     help="Run container in background & don't show container logs",
 )
+parser.add_argument(
+    "--no-cache",
+    dest="cache",
+    default=True,
+    action="store_false",
+    help="Don't use previously cached Docker images; rebuild them all",
+)
 # Set to false if your current user is already in the docker user group
 parser.add_argument(
-    "--sudo",
-    default=False,
-    action="store_true",
-    help="Run commands with sudo",
+    "--sudo", default=False, action="store_true", help="Run commands with sudo"
 )
 args = parser.parse_args()
 
-#Run docker ps without sudo to check if it can be used without
+# Run docker ps without sudo to check if it can be used without
 def check_docker_can_run():
     return subprocess.call(
-    ["docker", "ps"],
-    stdout=subprocess.DEVNULL,
-    stderr=subprocess.DEVNULL,
-    timeout=30
+        ["docker", "ps"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=30,
     )
+
 
 def current_user_in_group(group_name):
     try:
@@ -48,6 +53,7 @@ def current_user_in_group(group_name):
         return current_user in grp.getgrnam(group_name).gr_mem
     except KeyError:
         return False
+
 
 use_sudo = args.sudo
 if not args.sudo:
@@ -57,10 +63,12 @@ if not args.sudo:
 
 print("Running commands with sudo {}".format(use_sudo))
 
+
 def add_sudo(cmd_list):
     if use_sudo:
         cmd_list.insert(0, "sudo")
     return cmd_list
+
 
 if not os.path.exists("node_modules"):
     print("Node modules have not been installed yet, doing so now")
@@ -69,13 +77,13 @@ if not os.path.exists("node_modules"):
 print("Stopping {} container (if running)".format(CONTAINER_NAME))
 remove_container_cmd = ["docker", "rm", "--force", CONTAINER_NAME]
 subprocess.call(
-    add_sudo(remove_container_cmd),
-    stdout=subprocess.DEVNULL,
-    stderr=subprocess.STDOUT,
+    add_sudo(remove_container_cmd), stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
 )
 
 print("Building container")
 build_container_cmd = ["docker", "build", ".", "-t", IMAGE_NAME]
+if not args.cache:
+    build_container_cmd.append("--no-cache")
 subprocess.check_call(add_sudo(build_container_cmd))
 
 print("Starting container")


### PR DESCRIPTION
- Add --no-cache arg to run helper script. This forces all Docker images to be rebuilt - useful for debugging TravisCI failures.
- Use a fixed version of mc. Upstream have been making breaking changes to the command line args lately so stick with a specific version.
- Just use curl for all Dockerfile downloads instead of a fix of wget and curl.
- Remove --no-autocompletion arg to mc. It no longer supports this.
