### PR TITLE
New recordings CSV export API endpoint 

### DIFF
--- a/api/V1/File.js
+++ b/api/V1/File.js
@@ -63,9 +63,7 @@ module.exports = (app, baseUrl) => {
    * @apiGroup Files
    *
    * @apiHeader {String} Authorization Signed JSON web token for a user or device.
-   *
-   * @apiUse QueryParams
-   *
+   * @apiUse BaseQueryParams
    * @apiUse V1ResponseSuccessQuery
    */
   app.get(

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -185,15 +185,18 @@ module.exports = (app, baseUrl) => {
   );
 
   /**
-   * @api {get} /api/v1/recordings/report Generate report for a set of recordings.
-   * @apiName QueryRecordings
+   * @api {get} /api/v1/recordings/report Generate report for a set of recordings
+   * @apiName Report
    * @apiGroup Recordings
+   * @apiDescription Parameters are as per GET /api/V1/recordings. On
+   * success (status 200), the response body will contain CSV
+   * formatted details of the selected recordings.
    *
    * @apiUse V1UserAuthorizationHeader
-   *
-   * Parameters are the same as for /api/v1/recording.
-   *
-   * Output is
+   * @apiUse QueryParams
+   * @apiParam {JSON} [tags] As per GET /api/V1/recordings
+   * @apiParam {String} [tagMode] As per GET /api/V1/recordings
+   * @apiUse FilterOptions
    *
    * @apiUse V1ResponseError
    */

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 const { query, param, body } = require("express-validator/check");
+const csv = require("fast-csv");
 
 const middleware = require("../middleware");
 const auth = require("../auth");
@@ -123,6 +124,25 @@ module.exports = (app, baseUrl) => {
     middleware.requestWrapper(recordingUtil.makeUploadHandler())
   );
 
+  const queryValidators = Object.freeze([
+    auth.authenticateUser,
+    middleware.parseJSON("where", query).optional(),
+    query("offset")
+      .isInt()
+      .optional(),
+    query("limit")
+      .isInt()
+      .optional(),
+    middleware.parseJSON("order", query).optional(),
+    middleware.parseArray("tags", query).optional(),
+    query("tagMode")
+      .optional()
+      .custom(value => {
+        return models.Recording.isValidTagMode(value);
+      }),
+    middleware.parseJSON("filterOptions", query).optional()
+  ]);
+
   /**
    * @api {get} /api/v1/recordings Query available recordings
    * @apiName QueryRecordings
@@ -150,24 +170,7 @@ module.exports = (app, baseUrl) => {
    */
   app.get(
     apiUrl,
-    [
-      auth.authenticateUser,
-      middleware.parseJSON("where", query).optional(),
-      query("offset")
-        .isInt()
-        .optional(),
-      query("limit")
-        .isInt()
-        .optional(),
-      middleware.parseJSON("order", query).optional(),
-      middleware.parseArray("tags", query).optional(),
-      query("tagMode")
-        .optional()
-        .custom(value => {
-          return models.Recording.isValidTagMode(value);
-        }),
-      middleware.parseJSON("filterOptions", query).optional()
-    ],
+    queryValidators,
     middleware.requestWrapper(async (request, response) => {
       const result = await recordingUtil.query(request);
       responseUtil.send(response, {
@@ -178,6 +181,28 @@ module.exports = (app, baseUrl) => {
         count: result.count,
         rows: result.rows
       });
+    })
+  );
+
+  /**
+   * @api {get} /api/v1/recordings/report Generate report for a set of recordings.
+   * @apiName QueryRecordings
+   * @apiGroup Recordings
+   *
+   * @apiUse V1UserAuthorizationHeader
+   *
+   * Parameters are the same as for /api/v1/recording.
+   *
+   * Output is
+   *
+   * @apiUse V1ResponseError
+   */
+  app.get(
+    apiUrl + "/report",
+    queryValidators,
+    middleware.requestWrapper(async (request, response) => {
+      const rows = await recordingUtil.report(request);
+      csv.writeToStream(response.status(200), rows);
     })
   );
 

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -149,23 +149,10 @@ module.exports = (app, baseUrl) => {
    * @apiGroup Recordings
    *
    * @apiUse V1UserAuthorizationHeader
-   *
-   * @apiUse QueryParams
-   * @apiParam {JSON} [tags] Only return recordings tagged with one or more of the listed tags (JSON array).
-   * @apiParam {String} [tagMode] Only return recordings with specific types of tags. Valid values:
-   * <ul>
-   * <li>any: match recordings with any (or no) tag
-   * <li>untagged: match only recordings with no tags
-   * <li>tagged: match only recordings which have been tagged
-   * <li>no-human: match only recordings which are untagged or have been automatically tagged
-   * <li>automatic-only: match only recordings which have been automatically tagged
-   * <li>human-only: match only recordings which have been manually tagged
-   * <li>automatic+human: match only recordings which have been both automatically & manually tagged
-   * </ul>
+   * @apiUse BaseQueryParams
+   * @apiUse MoreQueryParams
    * @apiUse FilterOptions
-   *
    * @apiUse V1ResponseSuccessQuery
-   *
    * @apiUse V1ResponseError
    */
   app.get(
@@ -193,11 +180,9 @@ module.exports = (app, baseUrl) => {
    * formatted details of the selected recordings.
    *
    * @apiUse V1UserAuthorizationHeader
-   * @apiUse QueryParams
-   * @apiParam {JSON} [tags] As per GET /api/V1/recordings
-   * @apiParam {String} [tagMode] As per GET /api/V1/recordings
+   * @apiUse BaseQueryParams
+   * @apiUse MoreQueryParams
    * @apiUse FilterOptions
-   *
    * @apiUse V1ResponseError
    */
   app.get(

--- a/api/V1/Reprocess.js
+++ b/api/V1/Reprocess.js
@@ -46,13 +46,15 @@ module.exports = (app, baseUrl) => {
   );
 
   /**
-  * @api {post} /api/v1/reprocess marks recordings for reprocessing and archives tracks
+  * @api {post} /api/v1/reprocess Mark recordings for reprocessing
   * @apiName ReprocessMultiple
   * @apiGroup Recordings
   * @apiParam {JSON} recordings an array of recording ids to reprocess
-
-  * @apiDescription Marks multiple recordings for reprocessing and archives existing tracks
-
+  *
+  * @apiDescription Mark one or more recordings for reprocessing,
+  * archiving any tracks and recording tags that are associated with
+  * them.
+  *
   * @apiUse V1UserAuthorizationHeader
   *
   * @apiUse V1RecordingReprocessResponse

--- a/api/V1/apidoc.js
+++ b/api/V1/apidoc.js
@@ -28,7 +28,7 @@
  */
 
 /**
- * @apiDefine QueryParams
+ * @apiDefine BaseQueryParams
  * @apiParam {JSON} [where] Selection criteria as a map of keys and requried value, or a list of possible values.
  * * For example {"device": 1}  or {"name": ["bob", "charles"]}.
  * * All matches must be exact.
@@ -39,6 +39,21 @@
  * @apiParam {Number} [limit] Max number of records to be returned.
  * @apiParam {JSON} [order] Sorting order for records.
  * * For example, ["dateTime"] or [["dateTime", "ASC"]].
+ */
+
+/**
+ * @apiDefine MoreQueryParams
+ * @apiParam {JSON} [tags] Only return recordings tagged with one or more of the listed tags (JSON array).
+ * @apiParam {String} [tagMode] Only return recordings with specific types of tags. Valid values:
+ * <ul>
+ * <li>any: match recordings with any (or no) tag
+ * <li>untagged: match only recordings with no tags
+ * <li>tagged: match only recordings which have been tagged
+ * <li>no-human: match only recordings which are untagged or have been automatically tagged
+ * <li>automatic-only: match only recordings which have been automatically tagged
+ * <li>human-only: match only recordings which have been manually tagged
+ * <li>automatic+human: match only recordings which have been both automatically & manually tagged
+ * </ul>
  */
 
 /**

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -56,16 +56,22 @@ async function query(request, type) {
   // remove legacy tag mode selector (if included)
   delete request.query.where._tagged;
 
-  const result = await models.Recording.query(
+  const query = await models.Recording.makeBaseQuery(
     request.user,
     request.query.where,
     request.query.tagMode,
     request.query.tags,
     request.query.offset,
     request.query.limit,
-    request.query.order,
-    request.query.filterOptions
+    request.query.order
   );
+  const result = await models.Recording.findAndCountAll(query);
+
+  const filterOptions = models.Recording.makeFilterOptions(
+    request.user,
+    request.filterOptions
+  );
+  result.rows.map(rec => rec.filterData(filterOptions));
   result.rows = result.rows.map(handleLegacyTagFieldsForGetOnRecording);
   return result;
 }

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -101,7 +101,7 @@ async function report(request) {
   // recording to a audio file name so do some work first to look these up.
   const audioEvents = new Map();
   const audioFileIds = new Set();
-  for (let r of result) {
+  for (const r of result) {
     const event = findLatestEvent(r.Device.Events);
     if (event) {
       const fileId = event.EventDetail.details.fileId;
@@ -116,7 +116,7 @@ async function report(request) {
 
   // Bulk look up file details of played audio events.
   const audioFileNames = new Map();
-  for (let f of await models.File.getMultiple(Array.from(audioFileIds))) {
+  for (const f of await models.File.getMultiple(Array.from(audioFileIds))) {
     audioFileNames[f.id] = f.details.name;
   }
 
@@ -147,13 +147,13 @@ async function report(request) {
     ]
   ];
 
-  for (let r of result) {
+  for (const r of result) {
     r.filterData(filterOptions);
 
-    automatic_track_tags = new Set();
-    human_track_tags = new Set();
-    for (let track of r.Tracks) {
-      for (let tag of track.TrackTags) {
+    const automatic_track_tags = new Set();
+    const human_track_tags = new Set();
+    for (const track of r.Tracks) {
+      for (const tag of track.TrackTags) {
         const subject = tag.what || tag.detail;
         if (tag.automatic) {
           automatic_track_tags.add(subject);
@@ -208,20 +208,12 @@ function findLatestEvent(events) {
   }
 
   let latest = events[0];
-  for (let event of events) {
+  for (const event of events) {
     if (event.dateTime > latest.dateTime) {
       latest = event;
     }
   }
   return latest;
-}
-
-async function getAudioEventName(event) {
-  const fileInfo = await event.EventDetail.getFile();
-  if (!fileInfo) {
-    return null;
-  }
-  return fileInfo.details.name;
 }
 
 function formatTags(tags) {

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -120,10 +120,6 @@ async function report(request) {
     audioFileNames[f.id] = f.details.name;
   }
 
-  console.log(audioEvents);
-  console.log(audioFileIds);
-  console.log(audioFileNames);
-
   const recording_url_base = config.server.recording_url_base || "";
 
   const out = [

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -107,6 +107,7 @@ async function report(request) {
       const fileId = event.EventDetail.details.fileId;
       audioEvents[r.id] = {
         timestamp: event.dateTime,
+        volume: event.EventDetail.details.volume,
         fileId
       };
       audioFileIds.add(fileId);
@@ -138,9 +139,10 @@ async function report(request) {
       "automatic_track_tags",
       "human_track_tags",
       "recording_tags",
-      "last_audio_bait",
-      "last_audio_bait_time",
-      "mins_since_last_audio_bait",
+      "audio_bait",
+      "audio_bait_time",
+      "mins_since_audio_bait",
+      "audio_bait_volume",
       "url"
     ]
   ];
@@ -166,6 +168,7 @@ async function report(request) {
     let audioBaitName = "";
     let audioBaitTime = null;
     let audioBaitDelta = null;
+    let audioBaitVolume = null;
     const audioEvent = audioEvents[r.id];
     if (audioEvent) {
       audioBaitName = audioFileNames[audioEvent.fileId];
@@ -174,6 +177,7 @@ async function report(request) {
         .duration(r.recordingDateTime - audioBaitTime)
         .asMinutes()
         .toFixed(1);
+      audioBaitVolume = audioEvent.volume;
     }
 
     out.push([
@@ -191,6 +195,7 @@ async function report(request) {
       audioBaitName,
       audioBaitTime ? audioBaitTime.format() : "",
       audioBaitDelta,
+      audioBaitVolume,
       urljoin(recording_url_base, r.id.toString())
     ]);
   }

--- a/config/app_TEMPLATE.js
+++ b/config/app_TEMPLATE.js
@@ -7,7 +7,8 @@ const server = {
   http: {
     active: true,
     port: 80
-  }
+  },
+  recording_url_base: "http://localhost/recording"
 };
 
 const fileProcessing = {

--- a/config/app_test_default.js
+++ b/config/app_test_default.js
@@ -7,7 +7,8 @@ const server = {
   http: {
     active: true,
     port: 1080
-  }
+  },
+  recording_url_base: "http://test.site/recording"
 };
 
 const s3 = {

--- a/models/DetailSnapshot.js
+++ b/models/DetailSnapshot.js
@@ -86,7 +86,7 @@ module.exports = function(sequelize, DataTypes) {
       return null;
     }
     return await models.File.findByPk(fid);
-  }
+  };
 
   return DetailSnapshot;
 };

--- a/models/DetailSnapshot.js
+++ b/models/DetailSnapshot.js
@@ -31,6 +31,8 @@ module.exports = function(sequelize, DataTypes) {
 
   const DetailSnapshot = sequelize.define(name, attributes, options);
 
+  const models = sequelize.models;
+
   //---------------
   // CLASS METHODS
   //---------------
@@ -72,6 +74,19 @@ module.exports = function(sequelize, DataTypes) {
   DetailSnapshot.getFromId = async function(id) {
     return await this.findById(id);
   };
+
+
+  //-----------------
+  // INSTANCE METHODS
+  //-----------------
+
+  DetailSnapshot.prototype.getFile = async function() {
+    const fid = this.details.fileId;
+    if (!fid) {
+      return null;
+    }
+    return await models.File.findByPk(fid);
+  }
 
   return DetailSnapshot;
 };

--- a/models/File.js
+++ b/models/File.js
@@ -17,8 +17,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 "use strict";
+
 const _ = require("lodash");
+const sequelize = require('sequelize');
+const Op = sequelize.Op;
+
 const { AuthorizationError } = require("../api/customErrors");
+
+
 module.exports = function(sequelize, DataTypes) {
   const name = "File";
 
@@ -71,6 +77,16 @@ module.exports = function(sequelize, DataTypes) {
       );
     }
     await file.destroy();
+  };
+
+  File.getMultiple = async function(ids) {
+    return this.findAll({
+      where: {
+        "id": {
+          [Op.in]: ids
+        }
+      }
+    });
   };
 
   return File;

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -738,7 +738,7 @@ module.exports = function(sequelize, DataTypes) {
 
   // Include details of recent audio bait events in the query output.
   Recording.queryBuilder.prototype.addAudioEvents = function() {
-    deviceInclude = this.findInclude(models.Device);
+    const deviceInclude = this.findInclude(models.Device);
 
     if (!deviceInclude.include) {
       deviceInclude.include = {};
@@ -773,7 +773,7 @@ module.exports = function(sequelize, DataTypes) {
   };
 
   Recording.queryBuilder.prototype.findInclude = function(modelType) {
-    for (let inc of this.query.include) {
+    for (const inc of this.query.include) {
       if (inc.model === modelType) {
         return inc;
       }

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -197,12 +197,10 @@ module.exports = function(sequelize, DataTypes) {
       include: [
         {
           model: models.Group,
-          where: {},
           attributes: ["groupname"]
         },
         {
           model: models.Tag,
-          where: {},
           attributes: ["what", "detail", "automatic", "taggerId"],
           required: false
         },
@@ -217,15 +215,13 @@ module.exports = function(sequelize, DataTypes) {
             {
               model: models.TrackTag,
               attributes: ["what", "automatic", "UserId"],
-              where: {},
               required: false
             }
           ]
         },
         {
           model: models.Device,
-          where: {},
-          attributes: ["devicename"]
+          attributes: ["id", "devicename"]
         }
       ],
       limit: limit,

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,11 @@
         }
       }
     },
+    "@types/lodash": {
+      "version": "4.14.136",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA=="
+    },
     "@types/node": {
       "version": "12.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
@@ -1223,6 +1228,16 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "fast-csv": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-3.4.0.tgz",
+      "integrity": "sha512-/vPTDJc/l6VLOLIqcrMjuhyi8ZVTipTNl2GkVvaYiHlyh16oQMYPUkUVfREurT3MYE9j3mLQDk2Q8kPq30qQCg==",
+      "requires": {
+        "@types/lodash": "^4.14.132",
+        "@types/node": "^12.0.2",
+        "lodash": "^4.17.13"
+      }
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -6695,6 +6710,11 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express-validator": "^5.3.1",
     "express-winston": "^2.5.0",
     "extend": "^3.0.2",
+    "fast-csv": "^3.4.0",
     "fs": "0.0.2",
     "fstream": "^1.0.12",
     "install": "^0.12.2",
@@ -41,6 +42,7 @@
     "sequelize": "^5.8.12",
     "sequelize-cli": "^5.5.0",
     "tar": "^4.4.10",
+    "url-join": "^4.0.1",
     "uuid": "^3.2.1",
     "winston": "^1.0.1"
   },

--- a/test/deviceapi.py
+++ b/test/deviceapi.py
@@ -42,8 +42,8 @@ class DeviceAPI(APIBase):
         url = urljoin(self._baseurl, "/api/v1/events")
 
         response = requests.post(url, headers=self._auth_header, json=eventData)
-        self._check_response(response)
-        return response.json()["eventsAdded"], response.json()["eventDetailId"]
+        response_data = self._check_response(response)
+        return response_data["eventsAdded"], response_data["eventDetailId"]
 
     def get_audio_schedule(self):
         url = urljoin(self._baseurl, "/api/v1/schedules")

--- a/test/fileprocessingapi.py
+++ b/test/fileprocessingapi.py
@@ -64,5 +64,7 @@ class FileProcessingAPI:
         post_data = {"what": tag.what, "confidence": tag.confidence, "data": json.dumps(tag.data)}
         r = requests.post(url, data=post_data)
         if r.status_code == 200:
-            return r.json()["trackTagId"]
+            tag.id_ = r.json()["trackTagId"]
+            track.tags.append(tag)
+            return tag.id_
         raise_specific_exception(r)

--- a/test/recording.py
+++ b/test/recording.py
@@ -7,6 +7,9 @@ class Recording:
         # This will be printed out if a recordings query gives unexpected results.
         self.name = recording_name
 
+        self.tags = []
+        self.tracks = []
+
     def __repr__(self):
         return "<Recording: {}>".format(self.id_)
 
@@ -29,10 +32,12 @@ class TagPromise:
         self._tag = tag
 
     def by(self, user):
+        self._recording.tags.append(self._tag)
         return user.tag_recording(self._recording, self._tag)
 
     def byAI(self, user):
         self._tag["automatic"] = True
+        self._recording.tags.append(self._tag)
         return user.tag_recording(self._recording, self._tag)
 
 

--- a/test/test_file_processing.py
+++ b/test/test_file_processing.py
@@ -134,9 +134,8 @@ class TestFileProcessing:
         track.id_ = file_processing.add_track(recording, track)
 
         tag = TrackTag.create(track, automatic=True)
-        tag.id_ = file_processing.add_track_tag(track, tag)
-
-        user.can_see_track(track, [tag])
+        file_processing.add_track_tag(track, tag)
+        user.can_see_track(track)
 
     def test_reprocess_multiple_recordings(self, helper, file_processing):
         user = helper.admin_user()
@@ -204,10 +203,10 @@ class TestFileProcessing:
         track.id_ = file_processing.add_track(recording, track)
 
         tag = TrackTag.create(track, automatic=True)
-        tag.id_ = file_processing.add_track_tag(track, tag)
+        file_processing.add_track_tag(track, tag)
         return track, tag
 
-    def process_all_recordings(self, helper, file_processing):
+    def process_all_recordings(self, file_processing):
         recording = file_processing.get("thermalRaw", "getMetadata")
 
         while recording:
@@ -216,7 +215,7 @@ class TestFileProcessing:
             recording = file_processing.get("thermalRaw", "getMetadata")
 
     def test_reprocess_recording(self, helper, file_processing):
-        self.process_all_recordings(helper, file_processing)
+        self.process_all_recordings(file_processing)
         admin = helper.admin_user()
         recording, track, tag = self.create_processed_recording(
             helper, file_processing, admin, ai_tag="multiple animals", human_tag="possum"
@@ -228,7 +227,7 @@ class TestFileProcessing:
 
         db_recording = admin.get_recording(recording)
         assert len(db_recording["Tags"]) == 2
-        admin.can_see_track(track, [tag])
+        admin.can_see_track(track)
 
         admin.reprocess(recording)
         reprocessed_id = recording.id_
@@ -244,7 +243,7 @@ class TestFileProcessing:
         # check other recordings unaffected
         db_recording = admin.get_recording(recording2)
         assert len(db_recording["Tags"]) == 2
-        admin.can_see_track(track2, [tag2])
+        admin.can_see_track(track2)
         # check is returned when asking for another recording
         recording = file_processing.get("thermalRaw", "getMetadata")
         assert recording.id_ == reprocessed_id
@@ -258,7 +257,7 @@ class TestFileProcessing:
         check_recording(admin, recording, processingState="FINISHED", fileKey="some_key")
 
         track, tag = self.add_tracks_and_tag(file_processing, recording)
-        admin.can_see_track(track, [tag])
+        admin.can_see_track(track)
 
     def test_audio_reprocessing(self, helper, file_processing):
         admin = helper.admin_user()

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -5,37 +5,43 @@ import dateutil.tz
 
 class TestReport:
     def test_report(self, helper):
-        device = helper.given_new_device(self)
         user = helper.admin_user()
-        now = datetime.now()
 
-        # Add some audio events
+        # Two devices
+        device0 = helper.given_new_device(self)
+        device1 = helper.given_new_device(self)
+
+        # Add some audio events for device0 (device1 won't have any)
         now = datetime.now(dateutil.tz.tzlocal()).replace(microsecond=0)
         file_id = user.upload_audio_bait({"name": "other-sound"})
-        device.record_event("audioBait", {"fileId": file_id}, [now - timedelta(minutes=5)])
+        device0.record_event("audioBait", {"fileId": file_id}, [now - timedelta(minutes=5)])
 
         exp_audio_bait_name = "some-sound"
         exp_audio_bait_time = now - timedelta(minutes=2)  # newer
         file_id = user.upload_audio_bait({"name": exp_audio_bait_name})
-        device.record_event("audioBait", {"fileId": file_id}, [exp_audio_bait_time])
+        device0.record_event("audioBait", {"fileId": file_id}, [exp_audio_bait_time])
 
-        # Add 2 recordings
-        rec1 = device.upload_recording()
-        rec2 = device.upload_recording()
+        # Add 2 recordings for device0
+        rec0 = device0.upload_recording()
+        rec1 = device0.upload_recording()
+
+        # Add a recording for device1
+        rec2 = device1.upload_recording()
 
         # Add recording tag to 1st recording.
-        rec1.is_tagged_as(what="cool").by(user)
+        rec0.is_tagged_as(what="cool").by(user)
 
-        # Add track and track tags to 2nd recording.
-        user.update_recording(rec2, comment="foo")
-        track = user.can_add_track_to_recording(rec2)
+        # Add track and track tags to rec1
+        user.update_recording(rec1, comment="foo")
+        track = user.can_add_track_to_recording(rec1)
         user.can_tag_track(track, what="possum", automatic=True)
         user.can_tag_track(track, what="rat", automatic=False)
         user.can_tag_track(track, what="stoat", automatic=False)
 
         report = ReportChecker(user.get_report(limit=10))
-        report.check_line(rec1, device, exp_audio_bait_name, exp_audio_bait_time)
-        report.check_line(rec2, device, exp_audio_bait_name, exp_audio_bait_time)
+        report.check_line(rec0, device0, exp_audio_bait_name, exp_audio_bait_time)
+        report.check_line(rec1, device0, exp_audio_bait_name, exp_audio_bait_time)
+        report.check_line(rec2, device1, None, None)
 
 
 class ReportChecker:
@@ -73,11 +79,12 @@ class ReportChecker:
         assert line["human_track_tags"] == format_tags(expected_human_tags)
         assert line["recording_tags"] == format_tags(t["what"] for t in rec.tags)
 
-        assert line["last_audio_bait"] == exp_audio_bait_name
-        assert_times_equiv(dateutil.parser.parse(line["last_audio_bait_time"]), exp_audio_bait_time)
-        assert float(line["mins_since_last_audio_bait"]) == round(
-            (recording_time - exp_audio_bait_time).total_seconds() / 60, 1
-        )
+        if exp_audio_bait_name:
+            assert line["last_audio_bait"] == exp_audio_bait_name
+            assert_times_equiv(dateutil.parser.parse(line["last_audio_bait_time"]), exp_audio_bait_time)
+            assert float(line["mins_since_last_audio_bait"]) == round(
+                (recording_time - exp_audio_bait_time).total_seconds() / 60, 1
+            )
 
         assert line["url"] == "http://test.site/recording/" + str(rec.id_)
 

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -12,9 +12,7 @@ class TestReport:
         # Add some audio events
         now = datetime.now(dateutil.tz.tzlocal()).replace(microsecond=0)
         file_id = user.upload_audio_bait({"name": "other-sound"})
-        device.record_event(
-            "audioBait", {"fileId": file_id}, [now - timedelta(minutes=5)]
-        )
+        device.record_event("audioBait", {"fileId": file_id}, [now - timedelta(minutes=5)])
 
         exp_audio_bait_name = "some-sound"
         exp_audio_bait_time = now - timedelta(minutes=2)  # newer
@@ -76,9 +74,7 @@ class ReportChecker:
         assert line["recording_tags"] == format_tags(t["what"] for t in rec.tags)
 
         assert line["last_audio_bait"] == exp_audio_bait_name
-        assert_times_equiv(
-            dateutil.parser.parse(line["last_audio_bait_time"]), exp_audio_bait_time
-        )
+        assert_times_equiv(dateutil.parser.parse(line["last_audio_bait_time"]), exp_audio_bait_time)
         assert float(line["mins_since_last_audio_bait"]) == round(
             (recording_time - exp_audio_bait_time).total_seconds() / 60, 1
         )

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -19,7 +19,7 @@ class TestReport:
         exp_audio_bait_name = "some-sound"
         exp_audio_bait_time = now - timedelta(minutes=2)  # newer
         file_id = user.upload_audio_bait({"name": exp_audio_bait_name})
-        device0.record_event("audioBait", {"fileId": file_id}, [exp_audio_bait_time])
+        device0.record_event("audioBait", {"fileId": file_id, "volume": 8}, [exp_audio_bait_time])
 
         # Add 2 recordings for device0
         rec0 = device0.upload_recording()
@@ -80,11 +80,12 @@ class ReportChecker:
         assert line["recording_tags"] == format_tags(t["what"] for t in rec.tags)
 
         if exp_audio_bait_name:
-            assert line["last_audio_bait"] == exp_audio_bait_name
-            assert_times_equiv(dateutil.parser.parse(line["last_audio_bait_time"]), exp_audio_bait_time)
-            assert float(line["mins_since_last_audio_bait"]) == round(
+            assert line["audio_bait"] == exp_audio_bait_name
+            assert_times_equiv(dateutil.parser.parse(line["audio_bait_time"]), exp_audio_bait_time)
+            assert float(line["mins_since_audio_bait"]) == round(
                 (recording_time - exp_audio_bait_time).total_seconds() / 60, 1
             )
+            assert line["audio_bait_volume"] == "8"
 
         assert line["url"] == "http://test.site/recording/" + str(rec.id_)
 

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timedelta
+import dateutil.parser
+import dateutil.tz
+
+
+class TestReport:
+    def test_report(self, helper):
+        device = helper.given_new_device(self)
+        user = helper.admin_user()
+        now = datetime.now()
+
+        # Add some audio events
+        now = datetime.now(dateutil.tz.tzlocal()).replace(microsecond=0)
+        file_id = user.upload_audio_bait({"name": "other-sound"})
+        device.record_event(
+            "audioBait", {"fileId": file_id}, [now - timedelta(minutes=5)]
+        )
+
+        exp_audio_bait_name = "some-sound"
+        exp_audio_bait_time = now - timedelta(minutes=2)  # newer
+        file_id = user.upload_audio_bait({"name": exp_audio_bait_name})
+        device.record_event("audioBait", {"fileId": file_id}, [exp_audio_bait_time])
+
+        # Add 2 recordings
+        rec1 = device.upload_recording()
+        rec2 = device.upload_recording()
+
+        # Add recording tag to 1st recording.
+        rec1.is_tagged_as(what="cool").by(user)
+
+        # Add track and track tags to 2nd recording.
+        user.update_recording(rec2, comment="foo")
+        track = user.can_add_track_to_recording(rec2)
+        user.can_tag_track(track, what="possum", automatic=True)
+        user.can_tag_track(track, what="rat", automatic=False)
+        user.can_tag_track(track, what="stoat", automatic=False)
+
+        report = ReportChecker(user.get_report(limit=10))
+        report.check_line(rec1, device, exp_audio_bait_name, exp_audio_bait_time)
+        report.check_line(rec2, device, exp_audio_bait_name, exp_audio_bait_time)
+
+
+class ReportChecker:
+    def __init__(self, lines):
+        self._lines = {}
+        for line in lines:
+            recording_id = int(line["id"])
+            assert recording_id not in self._lines
+            self._lines[recording_id] = line
+
+    def check_line(self, rec, device, exp_audio_bait_name, exp_audio_bait_time):
+        line = self._lines.get(rec.id_)
+        assert line is not None
+
+        recording_time = dateutil.parser.parse(rec["recordingDateTime"])
+
+        assert line["type"] == rec["type"]
+        assert int(line["duration"]) == rec["duration"]
+        assert line["group"] == device.group
+        assert line["device"] == device.devicename
+        assert_times_equiv(dateutil.parser.parse(line["timestamp"]), recording_time)
+        assert line["comment"] == rec["comment"]
+        assert int(line["track_count"]) == len(rec.tracks)
+
+        expected_auto_tags = []
+        expected_human_tags = []
+        for track in rec.tracks:
+            for tag in track.tags:
+                if tag.automatic:
+                    expected_auto_tags.append(tag.what)
+                else:
+                    expected_human_tags.append(tag.what)
+
+        assert line["automatic_track_tags"] == format_tags(expected_auto_tags)
+        assert line["human_track_tags"] == format_tags(expected_human_tags)
+        assert line["recording_tags"] == format_tags(t["what"] for t in rec.tags)
+
+        assert line["last_audio_bait"] == exp_audio_bait_name
+        assert_times_equiv(
+            dateutil.parser.parse(line["last_audio_bait_time"]), exp_audio_bait_time
+        )
+        assert float(line["mins_since_last_audio_bait"]) == round(
+            (recording_time - exp_audio_bait_time).total_seconds() / 60, 1
+        )
+
+        assert line["url"] == "http://test.site/recording/" + str(rec.id_)
+
+
+def format_tags(items):
+    return "+".join(items)
+
+
+def assert_times_equiv(t1, t2):
+    t1 = t1.replace(microsecond=0)
+    t2 = t2.replace(microsecond=0)
+    assert (t1 - t2).total_seconds() == 0

--- a/test/test_tracks.py
+++ b/test/test_tracks.py
@@ -34,15 +34,15 @@ class TestTracks:
         track = user.can_add_track_to_recording(recording)
 
         # Add a track tag and ensure the user can see it.
-        tag0 = user.can_tag_track(track)
-        user.can_see_track(track, [tag0])
+        user.can_tag_track(track)
+        user.can_see_track(track)
 
         # Add another track tag and ensure the user can see that too.
-        tag1 = user.can_tag_track(track)
-        user.can_see_track(track, [tag0, tag1])
+        tag = user.can_tag_track(track)
+        user.can_see_track(track)
 
-        user.can_delete_track_tag(tag1)
-        user.can_see_track(track, [tag0])
+        user.can_delete_track_tag(tag)
+        user.can_see_track(track)
 
     def test_cant_add_track_tag_to_other_users_recording(self, helper):
         recording = helper.given_new_device(self, "tracks").has_recording()

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -54,9 +54,7 @@ class TestUser:
     def _can_see_recordings_with_query(self, queryParams, *expected_recordings):
         recordings = self._userapi.query(**queryParams)
         if not recordings:
-            raise TestException(
-                "User '{}' could not see any recordings.".format(self.username)
-            )
+            raise TestException("User '{}' could not see any recordings.".format(self.username))
 
         # Check presence of various fields
         r0 = recordings[0]
@@ -117,16 +115,12 @@ class TestUser:
 
     def can_see_recording_from(self, testdevice):
         recordings = self._userapi.query(limit=1)
-        assert recordings, "User '{}' could not see any recordings.".format(
-            self.username
-        )
+        assert recordings, "User '{}' could not see any recordings.".format(self.username)
 
         lastDevice = recordings[0]["Device"]["devicename"]
         assert (
             lastDevice == testdevice.devicename
-        ), "Latest recording is from device '{}', not from '{}'".format(
-            lastDevice, testdevice.devicename
-        )
+        ), "Latest recording is from device '{}', not from '{}'".format(lastDevice, testdevice.devicename)
 
     def cannot_see_any_recordings(self):
         recordings = self._userapi.query(limit=10)
@@ -179,9 +173,7 @@ class TestUser:
         assert recv_props.pop("processingState") != "FINISHED"
 
         # # Time formatting may differ so these are handled specially.
-        assertDateTimeStrings(
-            recv_props.pop("recordingDateTime"), props.pop("recordingDateTime")
-        )
+        assertDateTimeStrings(recv_props.pop("recordingDateTime"), props.pop("recordingDateTime"))
 
         # Compare the remaining properties.
         assert recv_props == props
@@ -201,9 +193,7 @@ class TestUser:
         try:
             self._userapi.create_group(groupname)
         except Exception as exception:
-            raise TestException(
-                "Failed to create group ({}): {}".format(groupname, exception)
-            )
+            raise TestException("Failed to create group ({}): {}".format(groupname, exception))
         if printname:
             print("({})".format(groupname))
         return groupname
@@ -252,15 +242,11 @@ class TestUser:
         deviceId = None
         if device is not None:
             deviceId = device.get_id()
-        return self._userapi.query_events(
-            deviceId=deviceId, startTime=startTime, endTime=endTime
-        )
+        return self._userapi.query_events(deviceId=deviceId, startTime=startTime, endTime=endTime)
 
     def cannot_see_events(self):
         events = self._userapi.query_events()
-        assert not events, "User '{}' can see events when it shouldn't".format(
-            self.username
-        )
+        assert not events, "User '{}' can see events when it shouldn't".format(self.username)
 
     def get_device_id(self, devicename):
         return self._userapi.get_device_id(devicename)
@@ -316,9 +302,7 @@ class TestUser:
         else:
             devicename = testdevice.devicename
 
-        recording_id = self._userapi.upload_recording_for(
-            testdevice.group, devicename, filename, props
-        )
+        recording_id = self._userapi.upload_recording_for(testdevice.group, devicename, filename, props)
 
         # Expect to see this in data returned by the API server.
         props["rawMimeType"] = "application/x-cptv"
@@ -441,9 +425,7 @@ class TestUser:
 
     def can_delete_track_tag(self, tag):
         self._userapi.delete_track_tag(
-            recording_id=tag.track.recording.id_,
-            track_id=tag.track.id_,
-            track_tag_id=tag.id_,
+            recording_id=tag.track.recording.id_, track_id=tag.track.id_, track_tag_id=tag.id_
         )
         tag.track.tags.remove(tag)
 
@@ -467,20 +449,14 @@ class RecordingQueryPromise:
         return self
 
     def devices(self, devices):
-        self._queryParams["deviceIds"] = list(
-            map(lambda device: device.get_id(), devices)
-        )
+        self._queryParams["deviceIds"] = list(map(lambda device: device.get_id(), devices))
         return self
 
     def can_see_recordings(self, *expected_recordings):
-        self._testUser._can_see_recordings_with_query(
-            self._queryParams, *expected_recordings
-        )
+        self._testUser._can_see_recordings_with_query(self._queryParams, *expected_recordings)
 
     def cannot_see_recordings(self, *expected_recordings):
-        self._testUser._cannot_see_recordings_with_query(
-            self._queryParams, *expected_recordings
-        )
+        self._testUser._cannot_see_recordings_with_query(self._queryParams, *expected_recordings)
 
     def can_see_all_recordings_from_(self, allRecordings):
         self.can_see_recordings(*allRecordings)
@@ -497,17 +473,13 @@ class RecordingQueryPromise:
             )
 
         ids = [testRecording.id_ for testRecording in self._expected_recordings]
-        print(
-            "Then searching with {} should give only {}.".format(self._queryParams, ids)
-        )
+        print("Then searching with {} should give only {}.".format(self._queryParams, ids))
 
         # test what should be there, is there
         self.can_see_recordings(*self._expected_recordings)
 
         # test what shouldn't be there, isn't there
-        expectedMissingRecordings = [
-            x for x in allRecordings if x not in self._expected_recordings
-        ]
+        expectedMissingRecordings = [x for x in allRecordings if x not in self._expected_recordings]
         self.cannot_see_recordings(*expectedMissingRecordings)
 
 

--- a/test/track.py
+++ b/test/track.py
@@ -8,6 +8,7 @@ class Track:
     id_ = attr.ib()
     recording = attr.ib()
     data = attr.ib()
+    tags = attr.ib(factory=list)
 
     @classmethod
     def create(cls, recording):
@@ -25,14 +26,17 @@ class TrackTag:
     data = attr.ib()
 
     @classmethod
-    def create(cls, track, automatic=None):
+    def create(cls, track, automatic=None, what=None):
         "Make a TestTrackTag with some plausible data."
         if automatic is None:
             automatic = random.choice([True, False])
+        if what is None:
+            what = random.choice(["possum", "rat", "stoat"])
+
         return cls(
             id_=None,
             track=track,
-            what=random.choice(["possum", "rat", "stoat"]),
+            what=what,
             confidence=random.choice([0.5, 0.8, 0.9]),
             automatic=automatic,
             data=random.choice([["foo", 1], ["bar", 2], ["what", 3]]),

--- a/test/track.py
+++ b/test/track.py
@@ -6,7 +6,7 @@ import attr
 @attr.s
 class Track:
     id_ = attr.ib()
-    recording = attr.ib()
+    recording = attr.ib(cmp=False)  # avoid cycles during comparsion
     data = attr.ib()
     tags = attr.ib(factory=list)
 
@@ -19,7 +19,7 @@ class Track:
 @attr.s
 class TrackTag:
     id_ = attr.ib()
-    track = attr.ib()
+    track = attr.ib(cmp=False)  # avoid cycles during comparsion
     what = attr.ib()
     confidence = attr.ib()
     automatic = attr.ib()

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -92,9 +92,7 @@ class UserAPI(APIBase):
             "tags": tags,
             "filterOptions": filterOptions,
         }
-        response = requests.get(
-            url, params=serialise_params(params), headers=self._auth_header
-        )
+        response = requests.get(url, params=serialise_params(params), headers=self._auth_header)
         if response.status_code == 200:
             return response.text
         raise_specific_exception(response)
@@ -116,24 +114,18 @@ class UserAPI(APIBase):
 
     def update_recording(self, recording_id, updates):
         url = urljoin(self._baseurl, "/api/v1/recordings/{}".format(recording_id))
-        r = requests.patch(
-            url, headers=self._auth_header, data={"updates": json.dumps(updates)}
-        )
+        r = requests.patch(url, headers=self._auth_header, data={"updates": json.dumps(updates)})
         return self._check_response(r)
 
     def reprocess(self, recording_id, params=None):
-        reprocessURL = urljoin(
-            self._baseurl, "/api/v1/reprocess/{}".format(recording_id)
-        )
+        reprocessURL = urljoin(self._baseurl, "/api/v1/reprocess/{}".format(recording_id))
         r = requests.get(reprocessURL, headers=self._auth_header, params=params)
         return self._check_response(r)
 
     def reprocess_recordings(self, recordings, params=None):
         reprocessURL = urljoin(self._baseurl, "/api/v1/reprocess")
         r = requests.post(
-            reprocessURL,
-            headers=self._auth_header,
-            data={"recordings": json.dumps(recordings)},
+            reprocessURL, headers=self._auth_header, data={"recordings": json.dumps(recordings)}
         )
         return r.status_code, r.json()
 
@@ -149,9 +141,7 @@ class UserAPI(APIBase):
         d = self._check_response(r)
         return self._download_signed(d[jwt_key])
 
-    def query_audio(
-        self, startDate=None, endDate=None, min_secs=0, limit=100, offset=0
-    ):
+    def query_audio(self, startDate=None, endDate=None, min_secs=0, limit=100, offset=0):
         headers = self._auth_header.copy()
 
         where = defaultdict(dict)
@@ -186,9 +176,7 @@ class UserAPI(APIBase):
 
     def update_audio_recording(self, recording_id, updates):
         url = urljoin(self._baseurl, "/api/v1/audiorecordings/{}".format(recording_id))
-        r = requests.put(
-            url, headers=self._auth_header, data={"data": json.dumps(updates)}
-        )
+        r = requests.put(url, headers=self._auth_header, data={"data": json.dumps(updates)})
         return self._check_response(r)
 
     def download_audio(self, recording_id):
@@ -198,11 +186,7 @@ class UserAPI(APIBase):
         return self._download_signed(d["jwt"])
 
     def _get_all(self, url):
-        r = requests.get(
-            urljoin(self._baseurl, url),
-            params={"where": "{}"},
-            headers=self._auth_header,
-        )
+        r = requests.get(urljoin(self._baseurl, url), params={"where": "{}"}, headers=self._auth_header)
         if r.status_code == 200:
             return r.json()
         raise_specific_exception(r)
@@ -225,9 +209,7 @@ class UserAPI(APIBase):
 
     def create_group(self, groupname):
         url = urljoin(self._baseurl, "/api/v1/groups")
-        response = requests.post(
-            url, headers=self._auth_header, data={"groupname": groupname}
-        )
+        response = requests.post(url, headers=self._auth_header, data={"groupname": groupname})
         self._check_response(response)
 
     def get_user_details(self, username):
@@ -244,20 +226,12 @@ class UserAPI(APIBase):
     def delete_recording_tag(self, tag_id):
         tagData = {"tagId": tag_id}
         response = requests.delete(
-            urljoin(self._baseurl, "/api/v1/tags".format(tag_id)),
-            headers=self._auth_header,
-            data=tagData,
+            urljoin(self._baseurl, "/api/v1/tags".format(tag_id)), headers=self._auth_header, data=tagData
         )
         return self._check_response(response)["messages"]
 
     def query_events(self, deviceId=None, startTime=None, endTime=None, limit=20):
-        return self._query(
-            "events",
-            deviceId=deviceId,
-            startTime=startTime,
-            endTime=endTime,
-            limit=limit,
-        )
+        return self._query("events", deviceId=deviceId, startTime=startTime, endTime=endTime, limit=limit)
 
     def query_files(self, where=None, limit=None, offset=None):
         if where is None:
@@ -276,9 +250,7 @@ class UserAPI(APIBase):
         params.setdefault("offset", 0)
         return_json = params.pop("return_json", False)
 
-        response = requests.get(
-            url, params=serialise_params(params), headers=self._auth_header
-        )
+        response = requests.get(url, params=serialise_params(params), headers=self._auth_header)
         if response.status_code == 200:
             if return_json:
                 return response.json()
@@ -292,15 +264,9 @@ class UserAPI(APIBase):
 
         with open(filename, "rb") as content:
             multipart_data = MultipartEncoder(
-                fields={
-                    "data": json_props,
-                    "file": (os.path.basename(filename), content),
-                }
+                fields={"data": json_props, "file": (os.path.basename(filename), content)}
             )
-            headers = {
-                "Content-Type": multipart_data.content_type,
-                "Authorization": self._token,
-            }
+            headers = {"Content-Type": multipart_data.content_type, "Authorization": self._token}
             r = requests.post(url, data=multipart_data, headers=headers)
         self._check_response(r)
         return r.json()["recordingId"]
@@ -330,9 +296,7 @@ class UserAPI(APIBase):
 
     def set_global_permission(self, user, permission):
         url = urljoin(self._baseurl, "/api/v1/admin/global_permission/" + user)
-        response = requests.patch(
-            url, headers=self._auth_header, data={"permission": permission}
-        )
+        response = requests.patch(url, headers=self._auth_header, data={"permission": permission})
         self._check_response(response)
 
     def add_user_to_group(self, newuser, groupname):
@@ -361,9 +325,7 @@ class UserAPI(APIBase):
 
     def list_device_users(self, deviceid):
         url = urljoin(self._baseurl, "/api/v1/devices/users")
-        response = requests.get(
-            url, headers=self._auth_header, params={"deviceId": deviceid}
-        )
+        response = requests.get(url, headers=self._auth_header, params={"deviceId": deviceid})
         return self._check_response(response).get("rows", [])
 
     def add_track(self, recording_id, data, algorithm={"status": "Test added"}):
@@ -383,20 +345,14 @@ class UserAPI(APIBase):
 
     def delete_track(self, recording_id, track_id):
         response = requests.delete(
-            urljoin(
-                self._baseurl,
-                "/api/v1/recordings/{}/tracks/{}".format(recording_id, track_id),
-            ),
+            urljoin(self._baseurl, "/api/v1/recordings/{}/tracks/{}".format(recording_id, track_id)),
             headers=self._auth_header,
         )
         return self._check_response(response)["messages"]
 
     def add_track_tag(self, recording_id, track_id, what, confidence, automatic, data):
         response = requests.post(
-            urljoin(
-                self._baseurl,
-                "/api/v1/recordings/{}/tracks/{}/tags".format(recording_id, track_id),
-            ),
+            urljoin(self._baseurl, "/api/v1/recordings/{}/tracks/{}/tags".format(recording_id, track_id)),
             headers=self._auth_header,
             data={
                 "what": what,
@@ -411,9 +367,7 @@ class UserAPI(APIBase):
         response = requests.delete(
             urljoin(
                 self._baseurl,
-                "/api/v1/recordings/{}/tracks/{}/tags/{}".format(
-                    recording_id, track_id, track_tag_id
-                ),
+                "/api/v1/recordings/{}/tracks/{}/tags/{}".format(recording_id, track_id, track_tag_id),
             ),
             headers=self._auth_header,
         )

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -62,6 +62,43 @@ class UserAPI(APIBase):
             return_json=return_json,
         )
 
+    def report(
+        self,
+        startDate=None,
+        endDate=None,
+        min_secs=0,
+        limit=100,
+        offset=0,
+        tagmode=None,
+        tags=None,
+        filterOptions=None,
+        deviceIds=None,
+    ):
+        where = defaultdict(dict)
+        where["duration"] = {"$gte": min_secs}
+        if startDate is not None:
+            where["recordingDateTime"]["$gte"] = startDate.isoformat()
+        if endDate is not None:
+            where["recordingDateTime"]["$lte"] = endDate.isoformat()
+        if deviceIds is not None:
+            where["DeviceId"] = deviceIds
+
+        url = urljoin(self._baseurl, "/api/v1/recordings/report")
+        params = {
+            "where": where,
+            "limit": limit,
+            "offset": offset,
+            "tagMode": tagmode,
+            "tags": tags,
+            "filterOptions": filterOptions,
+        }
+        response = requests.get(
+            url, params=serialise_params(params), headers=self._auth_header
+        )
+        if response.status_code == 200:
+            return response.text
+        raise_specific_exception(response)
+
     def update_user(self, body):
         url = urljoin(self._baseurl, "/api/v1/users")
         response = requests.patch(url, data=body, headers=self._auth_header)
@@ -79,18 +116,24 @@ class UserAPI(APIBase):
 
     def update_recording(self, recording_id, updates):
         url = urljoin(self._baseurl, "/api/v1/recordings/{}".format(recording_id))
-        r = requests.patch(url, headers=self._auth_header, data={"updates": json.dumps(updates)})
+        r = requests.patch(
+            url, headers=self._auth_header, data={"updates": json.dumps(updates)}
+        )
         return self._check_response(r)
 
     def reprocess(self, recording_id, params=None):
-        reprocessURL = urljoin(self._baseurl, "/api/v1/reprocess/{}".format(recording_id))
+        reprocessURL = urljoin(
+            self._baseurl, "/api/v1/reprocess/{}".format(recording_id)
+        )
         r = requests.get(reprocessURL, headers=self._auth_header, params=params)
         return self._check_response(r)
 
     def reprocess_recordings(self, recordings, params=None):
         reprocessURL = urljoin(self._baseurl, "/api/v1/reprocess")
         r = requests.post(
-            reprocessURL, headers=self._auth_header, data={"recordings": json.dumps(recordings)}
+            reprocessURL,
+            headers=self._auth_header,
+            data={"recordings": json.dumps(recordings)},
         )
         return r.status_code, r.json()
 
@@ -106,7 +149,9 @@ class UserAPI(APIBase):
         d = self._check_response(r)
         return self._download_signed(d[jwt_key])
 
-    def query_audio(self, startDate=None, endDate=None, min_secs=0, limit=100, offset=0):
+    def query_audio(
+        self, startDate=None, endDate=None, min_secs=0, limit=100, offset=0
+    ):
         headers = self._auth_header.copy()
 
         where = defaultdict(dict)
@@ -141,7 +186,9 @@ class UserAPI(APIBase):
 
     def update_audio_recording(self, recording_id, updates):
         url = urljoin(self._baseurl, "/api/v1/audiorecordings/{}".format(recording_id))
-        r = requests.put(url, headers=self._auth_header, data={"data": json.dumps(updates)})
+        r = requests.put(
+            url, headers=self._auth_header, data={"data": json.dumps(updates)}
+        )
         return self._check_response(r)
 
     def download_audio(self, recording_id):
@@ -151,7 +198,11 @@ class UserAPI(APIBase):
         return self._download_signed(d["jwt"])
 
     def _get_all(self, url):
-        r = requests.get(urljoin(self._baseurl, url), params={"where": "{}"}, headers=self._auth_header)
+        r = requests.get(
+            urljoin(self._baseurl, url),
+            params={"where": "{}"},
+            headers=self._auth_header,
+        )
         if r.status_code == 200:
             return r.json()
         raise_specific_exception(r)
@@ -174,7 +225,9 @@ class UserAPI(APIBase):
 
     def create_group(self, groupname):
         url = urljoin(self._baseurl, "/api/v1/groups")
-        response = requests.post(url, headers=self._auth_header, data={"groupname": groupname})
+        response = requests.post(
+            url, headers=self._auth_header, data={"groupname": groupname}
+        )
         self._check_response(response)
 
     def get_user_details(self, username):
@@ -191,12 +244,20 @@ class UserAPI(APIBase):
     def delete_recording_tag(self, tag_id):
         tagData = {"tagId": tag_id}
         response = requests.delete(
-            urljoin(self._baseurl, "/api/v1/tags".format(tag_id)), headers=self._auth_header, data=tagData
+            urljoin(self._baseurl, "/api/v1/tags".format(tag_id)),
+            headers=self._auth_header,
+            data=tagData,
         )
         return self._check_response(response)["messages"]
 
     def query_events(self, deviceId=None, startTime=None, endTime=None, limit=20):
-        return self._query("events", deviceId=deviceId, startTime=startTime, endTime=endTime, limit=limit)
+        return self._query(
+            "events",
+            deviceId=deviceId,
+            startTime=startTime,
+            endTime=endTime,
+            limit=limit,
+        )
 
     def query_files(self, where=None, limit=None, offset=None):
         if where is None:
@@ -213,18 +274,11 @@ class UserAPI(APIBase):
 
         params.setdefault("limit", 100)
         params.setdefault("offset", 0)
-
         return_json = params.pop("return_json", False)
-        req_params = {}
-        for name, value in params.items():
-            if value is not None:
-                if isinstance(value, (dict, list, tuple)):
-                    value = json.dumps(value)
-                elif isinstance(value, datetime):
-                    value = value.isoformat()
-                req_params[name] = value
 
-        response = requests.get(url, params=req_params, headers=self._auth_header)
+        response = requests.get(
+            url, params=serialise_params(params), headers=self._auth_header
+        )
         if response.status_code == 200:
             if return_json:
                 return response.json()
@@ -238,9 +292,15 @@ class UserAPI(APIBase):
 
         with open(filename, "rb") as content:
             multipart_data = MultipartEncoder(
-                fields={"data": json_props, "file": (os.path.basename(filename), content)}
+                fields={
+                    "data": json_props,
+                    "file": (os.path.basename(filename), content),
+                }
             )
-            headers = {"Content-Type": multipart_data.content_type, "Authorization": self._token}
+            headers = {
+                "Content-Type": multipart_data.content_type,
+                "Authorization": self._token,
+            }
             r = requests.post(url, data=multipart_data, headers=headers)
         self._check_response(r)
         return r.json()["recordingId"]
@@ -270,7 +330,9 @@ class UserAPI(APIBase):
 
     def set_global_permission(self, user, permission):
         url = urljoin(self._baseurl, "/api/v1/admin/global_permission/" + user)
-        response = requests.patch(url, headers=self._auth_header, data={"permission": permission})
+        response = requests.patch(
+            url, headers=self._auth_header, data={"permission": permission}
+        )
         self._check_response(response)
 
     def add_user_to_group(self, newuser, groupname):
@@ -299,7 +361,9 @@ class UserAPI(APIBase):
 
     def list_device_users(self, deviceid):
         url = urljoin(self._baseurl, "/api/v1/devices/users")
-        response = requests.get(url, headers=self._auth_header, params={"deviceId": deviceid})
+        response = requests.get(
+            url, headers=self._auth_header, params={"deviceId": deviceid}
+        )
         return self._check_response(response).get("rows", [])
 
     def add_track(self, recording_id, data, algorithm={"status": "Test added"}):
@@ -319,14 +383,20 @@ class UserAPI(APIBase):
 
     def delete_track(self, recording_id, track_id):
         response = requests.delete(
-            urljoin(self._baseurl, "/api/v1/recordings/{}/tracks/{}".format(recording_id, track_id)),
+            urljoin(
+                self._baseurl,
+                "/api/v1/recordings/{}/tracks/{}".format(recording_id, track_id),
+            ),
             headers=self._auth_header,
         )
         return self._check_response(response)["messages"]
 
     def add_track_tag(self, recording_id, track_id, what, confidence, automatic, data):
         response = requests.post(
-            urljoin(self._baseurl, "/api/v1/recordings/{}/tracks/{}/tags".format(recording_id, track_id)),
+            urljoin(
+                self._baseurl,
+                "/api/v1/recordings/{}/tracks/{}/tags".format(recording_id, track_id),
+            ),
             headers=self._auth_header,
             data={
                 "what": what,
@@ -341,8 +411,22 @@ class UserAPI(APIBase):
         response = requests.delete(
             urljoin(
                 self._baseurl,
-                "/api/v1/recordings/{}/tracks/{}/tags/{}".format(recording_id, track_id, track_tag_id),
+                "/api/v1/recordings/{}/tracks/{}/tags/{}".format(
+                    recording_id, track_id, track_tag_id
+                ),
             ),
             headers=self._auth_header,
         )
         return self._check_response(response)["messages"]
+
+
+def serialise_params(params):
+    out = {}
+    for name, value in params.items():
+        if value is not None:
+            if isinstance(value, (dict, list, tuple)):
+                value = json.dumps(value)
+            elif isinstance(value, datetime):
+                value = value.isoformat()
+            out[name] = value
+    return out


### PR DESCRIPTION
This new endpoint which takes the same query parameters as the main query API but generates a CSV. This CSV includes extra information such as details of the most recently played audio bait event.

To faciltate this change the recording query logic has been factored out into its own query builder object. The creation of the tests for this feature lead to various improvements in the API server test infrastructure.