### PR TITLE
Replace check-style script with pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 script:
  - npm run lint
- - test/check-style
+ - black --diff --check ./test
  - ./wait-for-api || { docker ps; docker logs cacophony-api; exit 1; }
  - cd test
  - pytest --log-api-on-fail

--- a/test/check-style
+++ b/test/check-style
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-dir=$(dirname $0)
-black $dir/*.py --target-version=py36 --check --diff -l 110

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 110
+target_version = ['py36']


### PR DESCRIPTION
This avoids custom tooling and hopefully helps with IDE support (pyproject.toml is becoming a defacto standard)