### PR TITLE
Fix dubious filter expression for CSV report audio bait events

### DIFF
--- a/models/Recording.js
+++ b/models/Recording.js
@@ -749,10 +749,12 @@ module.exports = function(sequelize, DataTypes) {
         required: false,
         where: {
           dateTime: {
-            [Op.lt]: sequelize.literal('"Recording"."recordingDateTime"'),
-            [Op.gt]: sequelize.literal(
-              '"Recording"."recordingDateTime" - interval \'30 minutes\''
-            )
+            [Op.between]: [
+              sequelize.literal(
+                '"Recording"."recordingDateTime" - interval \'30 minutes\''
+              ),
+              sequelize.literal('"Recording"."recordingDateTime"')
+            ]
           }
         },
         include: [


### PR DESCRIPTION
This might have been causing occasional test failures.