### PR TITLE
Allow CSV reports to be generated using a JWT argument

### DIFF
--- a/api/V1/AuthenticateDevice.js
+++ b/api/V1/AuthenticateDevice.js
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const { body } = require("express-validator/check");
 
 const auth = require("../auth");
-const config = require("../../config");
 const responseUtil = require("./responseUtil");
 const middleware = require("../middleware");
 

--- a/api/V1/AuthenticateDevice.js
+++ b/api/V1/AuthenticateDevice.js
@@ -16,7 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-const jwt = require("jsonwebtoken");
+const auth = require("../auth");
 const config = require("../../config");
 const responseUtil = require("./responseUtil");
 const middleware = require("../middleware");
@@ -45,13 +45,11 @@ module.exports = function(app) {
         request.body.password
       );
       if (passwordMatch) {
-        const data = request.body.device.getJwtDataValues();
-        const token = "JWT " + jwt.sign(data, config.server.passportSecret);
         return responseUtil.send(response, {
           statusCode: 200,
           messages: ["Successful login."],
           id: request.body.device.id,
-          token: token
+          token: "JWT " + auth.createEntityJWT(request.body.device)
         });
       } else {
         return responseUtil.send(response, {

--- a/api/V1/AuthenticateDevice.js
+++ b/api/V1/AuthenticateDevice.js
@@ -16,11 +16,12 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+const { body } = require("express-validator/check");
+
 const auth = require("../auth");
 const config = require("../../config");
 const responseUtil = require("./responseUtil");
 const middleware = require("../middleware");
-const { body } = require("express-validator/check");
 
 module.exports = function(app) {
   /**

--- a/api/V1/AuthenticateUser.js
+++ b/api/V1/AuthenticateUser.js
@@ -17,10 +17,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 const jwt = require("jsonwebtoken");
-const config = require("../../config");
+const { body, oneOf } = require("express-validator/check");
+
+const auth = require("../auth");
 const responseUtil = require("./responseUtil");
 const middleware = require("../middleware");
-const { body, oneOf } = require("express-validator/check");
 
 module.exports = function(app) {
   /**
@@ -57,17 +58,16 @@ module.exports = function(app) {
         request.body.password
       );
       if (passwordMatch) {
+        const token = await auth.createEntityJWT(request.body.user);
         const userData = await request.body.user.getDataValues();
-        const data = request.body.user.getJwtDataValues();
-        data._type = "user";
-        return responseUtil.send(response, {
+        responseUtil.send(response, {
           statusCode: 200,
           messages: ["Successful login."],
-          token: "JWT " + jwt.sign(data, config.server.passportSecret),
+          token: "JWT " + token,
           userData: userData
         });
       } else {
-        return responseUtil.send(response, {
+        responseUtil.send(response, {
           statusCode: 401,
           messages: ["Wrong password or username."]
         });

--- a/api/V1/AuthenticateUser.js
+++ b/api/V1/AuthenticateUser.js
@@ -91,7 +91,7 @@ module.exports = function(app) {
     "/token",
     [auth.authenticateUser],
     middleware.requestWrapper(async (request, response) => {
-      const token = auth.createEntityJWT(request.user, { expiresIn: 60 * 5 });
+      const token = auth.createEntityJWT(request.user, { expiresIn: 60 });
       responseUtil.send(response, {
         statusCode: 200,
         messages: ["Token generated."],

--- a/api/V1/AuthenticateUser.js
+++ b/api/V1/AuthenticateUser.js
@@ -16,7 +16,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-const jwt = require("jsonwebtoken");
 const { body, oneOf } = require("express-validator/check");
 
 const auth = require("../auth");
@@ -77,7 +76,7 @@ module.exports = function(app) {
 
 
   /**
-   * @api {post} /token Generate temporary JWT for the current user
+   * @api {post} /token Generate temporary JWT
    * @apiName Token
    * @apiGroup Authentication
    * @apiDescription It is sometimes necessary to include an

--- a/api/V1/AuthenticateUser.js
+++ b/api/V1/AuthenticateUser.js
@@ -74,4 +74,30 @@ module.exports = function(app) {
       }
     })
   );
+
+
+  /**
+   * @api {post} /token Generate temporary JWT for the current user
+   * @apiName Token
+   * @apiGroup Authentication
+   * @apiDescription It is sometimes necessary to include an
+   * authentication token in a URL but it is not safe to provide a
+   * user's primary JWT as it can easily leak into logs etc. This API
+   * generates a short-lived token which can be used as part of URLs.
+   *
+   * @apiUse V1UserAuthorizationHeader
+   * @apiSuccess {JSON} token JWT that may be used to call the report endpoint.
+   */
+  app.post(
+    "/token",
+    [auth.authenticateUser],
+    middleware.requestWrapper(async (request, response) => {
+      const token = auth.createEntityJWT(request.user, { expiresIn: 60 * 5 });
+      responseUtil.send(response, {
+        statusCode: 200,
+        messages: ["Token generated."],
+        token: token
+      });
+    })
+  );
 };

--- a/api/V1/Device.js
+++ b/api/V1/Device.js
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 const models = require("../../models");
-const jwt = require("jsonwebtoken");
-const config = require("../../config");
 const responseUtil = require("./responseUtil");
 const middleware = require("../middleware");
 const auth = require("../auth");
@@ -62,12 +60,11 @@ module.exports = function(app, baseUrl) {
         GroupId: request.body.group.id
       });
 
-      const data = device.getJwtDataValues();
       return responseUtil.send(response, {
         statusCode: 200,
         messages: ["Created new device."],
         id: device.id,
-        token: "JWT " + jwt.sign(data, config.server.passportSecret)
+        token: "JWT " + auth.createEntityJWT(device)
       });
     })
   );

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -187,7 +187,7 @@ module.exports = (app, baseUrl) => {
    */
   app.get(
     apiUrl + "/report",
-    [auth.byJWTParam("user", "user")].concat(queryValidators),
+    [auth.paramOrHeader].concat(queryValidators),
     middleware.requestWrapper(async (request, response) => {
       const rows = await recordingUtil.report(request);
       response.status(200).set({

--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -179,7 +179,7 @@ module.exports = (app, baseUrl) => {
    * formatted details of the selected recordings.
    *
    * @apiUse V1UserAuthorizationHeader
-   * @apiParam {String} [jwt] Signed JWT as produced by the token endpoint XXX.
+   * @apiParam {String} [jwt] Signed JWT as produced by the [Token](#api-Authentication-Token) endpoint
    * @apiUse BaseQueryParams
    * @apiUse MoreQueryParams
    * @apiUse FilterOptions
@@ -195,31 +195,6 @@ module.exports = (app, baseUrl) => {
         'Content-Disposition': 'attachment; filename=recordings.csv'
       });
       csv.writeToStream(response, rows);
-    })
-  );
-
-  // XXX move to move general location
-  /**
-   * @api {post} /api/v1/recordings/report/token Generate temporary JWT for accessing /api/v1/recordings/report
-   * @apiName ReportJWT
-   * @apiGroup Recordings
-   * @apiDescription Use this to obtain a JWT to use as the (optional)
-   * "jwt" argument for the report endpoint.
-   *
-   * @apiUse V1UserAuthorizationHeader
-   * @apiSuccess {JSON} jwt JWT that may be used to call the report endpoint.
-   */
-  app.post(
-    apiUrl + "/report/token",
-    [auth.authenticateUser].concat(queryValidators),
-    middleware.requestWrapper(async (request, response) => {
-      // Issue a short-lived user token for accessing the recordings report.
-      const token = auth.createEntityJWT(request.user, { expiresIn: 60 * 5 });
-      responseUtil.send(response, {
-        statusCode: 200,
-        messages: ["Token generated."],
-        jwt: token
-      });
     })
   );
 

--- a/api/V1/User.js
+++ b/api/V1/User.js
@@ -17,8 +17,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 const models = require("../../models");
-const jwt = require("jsonwebtoken");
-const config = require("../../config");
 const responseUtil = require("./responseUtil");
 const middleware = require("../middleware");
 const auth = require("../auth");
@@ -64,13 +62,12 @@ module.exports = function(app, baseUrl) {
         email: request.body.email
       });
 
-      const jwtData = user.getJwtDataValues();
       const userData = await user.getDataValues();
 
       return responseUtil.send(response, {
         statusCode: 200,
         messages: ["Created new user."],
-        token: "JWT " + jwt.sign(jwtData, config.server.passportSecret),
+        token: "JWT " + auth.createEntityJWT(user),
         userData: userData
       });
     })

--- a/api/V1/signedUrl.js
+++ b/api/V1/signedUrl.js
@@ -32,9 +32,14 @@ module.exports = function(app, baseUrl) {
    * @apiName GetFile
    * @apiGroup SignedUrl
    *
-   * @apiDescription Gets a file using a JWT as a method of authentication.
+   * @apiDescription Gets a file. The JWT for authentication may be
+   * passed using a URL parameter or using the Authorization header
+   * (as for other API endpoints).
    *
-   * @apiParam {String} jwt the value of the downloadFileJWT field from a successful [GetRecording](#api-Recordings-GetRecording) request
+   * @apiParam {String} [jwt] the value of the downloadFileJWT field
+   * from a successful [GetRecording](#api-Recordings-GetRecording)
+   * request. Authentication using the Authorization header is also
+   * supported.
    *
    * @apiSuccess {file} file Raw data stream of the file.
    *
@@ -43,7 +48,7 @@ module.exports = function(app, baseUrl) {
 
   app.get(
     baseUrl + "/signedUrl",
-    [auth.fileDownload],
+    [auth.byJWTParam("fileDownload", null)],
     middleware.requestWrapper(async (request, response) => {
       const mimeType = request.jwtDecoded.mimeType || "";
       const filename = request.jwtDecoded.filename || "file";

--- a/api/V1/signedUrl.js
+++ b/api/V1/signedUrl.js
@@ -43,7 +43,7 @@ module.exports = function(app, baseUrl) {
 
   app.get(
     baseUrl + "/signedUrl",
-    [auth.signedUrl],
+    [auth.fileDownload],
     middleware.requestWrapper(async (request, response) => {
       const mimeType = request.jwtDecoded.mimeType || "";
       const filename = request.jwtDecoded.filename || "file";

--- a/api/V1/signedUrl.js
+++ b/api/V1/signedUrl.js
@@ -48,7 +48,7 @@ module.exports = function(app, baseUrl) {
 
   app.get(
     baseUrl + "/signedUrl",
-    [auth.byJWTParam("fileDownload", null)],
+    [auth.signedUrl],
     middleware.requestWrapper(async (request, response) => {
       const mimeType = request.jwtDecoded.mimeType || "";
       const filename = request.jwtDecoded.filename || "file";

--- a/api/auth.js
+++ b/api/auth.js
@@ -20,7 +20,6 @@ const config = require("../config");
 const jwt = require("jsonwebtoken");
 const ExtractJwt = require("passport-jwt").ExtractJwt;
 const customErrors = require("./customErrors");
-const format = require("util").format;
 const models = require("../models");
 
 /*

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -59,9 +59,8 @@ class TestReport:
         device = helper.given_new_device(self)
         rec = device.upload_recording()
 
-        # Get report using JWT argument
-        jwt = user.get_report_token()
-        report = ReportChecker(user.get_report(limit=5, jwt=jwt))
+        token = user.new_token()
+        report = ReportChecker(user.get_report(limit=5, jwt=token))
 
         report.check_line(rec, device)
 

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -50,7 +50,20 @@ class TestReport:
         report = ReportChecker(user.get_report(limit=10))
         report.check_line(rec0, device0, exp_audio_bait_name, exp_audio_bait_time)
         report.check_line(rec1, device0, exp_audio_bait_name, exp_audio_bait_time)
-        report.check_line(rec2, device1, None, None)
+        report.check_line(rec2, device1)
+
+
+    def test_report_jwt_arg(self, helper):
+        user = helper.admin_user()
+
+        device = helper.given_new_device(self)
+        rec = device.upload_recording()
+
+        # Get report using JWT argument
+        jwt = user.get_report_token()
+        report = ReportChecker(user.get_report(limit=5, jwt=jwt))
+
+        report.check_line(rec, device)
 
 
 class ReportChecker:
@@ -61,7 +74,7 @@ class ReportChecker:
             assert recording_id not in self._lines
             self._lines[recording_id] = line
 
-    def check_line(self, rec, device, exp_audio_bait_name, exp_audio_bait_time):
+    def check_line(self, rec, device, exp_audio_bait_name=None, exp_audio_bait_time=None):
         line = self._lines.get(rec.id_)
         assert line is not None
 

--- a/test/test_report.py
+++ b/test/test_report.py
@@ -52,7 +52,6 @@ class TestReport:
         report.check_line(rec1, device0, exp_audio_bait_name, exp_audio_bait_time)
         report.check_line(rec2, device1)
 
-
     def test_report_jwt_arg(self, helper):
         user = helper.admin_user()
 

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -135,6 +135,9 @@ class TestUser:
         text = self._userapi.report(**args)
         return csv.DictReader(text.splitlines())
 
+    def get_report_token(self):
+        return self._userapi.report_token()['jwt']
+
     def can_download_correct_recording(self, recording):
         content = io.BytesIO()
         for chunk in self._userapi.download_cptv(recording.id_):

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -14,6 +14,9 @@ class TestUser:
         self.email = email
         self._group = None
 
+    def new_token(self):
+        return self._userapi.token()['token']
+
     def update(self, username=None, email=None, password=None):
         data = {}
         if username:
@@ -134,9 +137,6 @@ class TestUser:
     def get_report(self, **args):
         text = self._userapi.report(**args)
         return csv.DictReader(text.splitlines())
-
-    def get_report_token(self):
-        return self._userapi.report_token()['jwt']
 
     def can_download_correct_recording(self, recording):
         content = io.BytesIO()

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -15,7 +15,7 @@ class TestUser:
         self._group = None
 
     def new_token(self):
-        return self._userapi.token()['token']
+        return self._userapi.token()["token"]
 
     def update(self, username=None, email=None, password=None):
         data = {}

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -73,6 +73,7 @@ class UserAPI(APIBase):
         tags=None,
         filterOptions=None,
         deviceIds=None,
+        jwt=None,
     ):
         where = defaultdict(dict)
         where["duration"] = {"$gte": min_secs}
@@ -92,10 +93,22 @@ class UserAPI(APIBase):
             "tags": tags,
             "filterOptions": filterOptions,
         }
-        response = requests.get(url, params=serialise_params(params), headers=self._auth_header)
+
+        if jwt:
+            params["jwt"] = jwt
+            headers = None
+        else:
+            headers = self._auth_header
+
+        response = requests.get(url, params=serialise_params(params), headers=headers)
         if response.status_code == 200:
             return response.text
         raise_specific_exception(response)
+
+    def report_token(self):
+        url = urljoin(self._baseurl, "/api/v1/recordings/report/token")
+        response = requests.post(url, headers=self._auth_header)
+        return self._check_response(response)
 
     def update_user(self, body):
         url = urljoin(self._baseurl, "/api/v1/users")

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -22,6 +22,10 @@ class UserAPI(APIBase):
     def login(self):
         return super().login(email=self.email)
 
+    def token(self):
+        response = requests.post(urljoin(self._baseurl, "/token"), headers=self._auth_header)
+        return self._check_response(response)
+
     def name_or_email_login(self, nameOrEmail):
         url = urljoin(self._baseurl, "/authenticate_" + self._logintype)
         data = {"nameOrEmail": nameOrEmail, "password": self._password}
@@ -104,11 +108,6 @@ class UserAPI(APIBase):
         if response.status_code == 200:
             return response.text
         raise_specific_exception(response)
-
-    def report_token(self):
-        url = urljoin(self._baseurl, "/api/v1/recordings/report/token")
-        response = requests.post(url, headers=self._auth_header)
-        return self._check_response(response)
 
     def update_user(self, body):
         url = urljoin(self._baseurl, "/api/v1/users")


### PR DESCRIPTION
- added /token endpoint which generates a short-lived JWT for a user
- these tokens are now accepted by the report endpoint
- lots of refactoring and cleanup of authentication code 

Still to come:
- further auth refactoring (it can be simplier and "simple is Good" when it comes to authentication
- limit temporary tokens to specific parts of the API