### PR TITLE
Restore the legacy /api/v1/recordings/:devicename POST endpoint 

### DIFF
--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -143,6 +143,34 @@ module.exports = (app, baseUrl) => {
   ]);
 
   /**
+   * @api {post} /api/v1/recordings/:devicename Legacy upload on behalf of
+   * @apiName PostRecordingOnBehalfLegacy
+   * @apiGroup Recordings
+   * @apiDeprecated use now (#Recordings:PostRecordingOnBehalf)
+   *
+   * @apiDescription Called by a user to upload raw thermal video on
+   * behalf of a device. This endpoint can only be used if a device's
+   * name is unique across all groups. It should not be used for new code.
+   *
+   * @apiUse V1UserAuthorizationHeader
+   *
+   * @apiUse RecordingParams
+   *
+   * @apiUse V1ResponseSuccess
+   * @apiSuccess {Number} recordingId ID of the recording.
+   * @apiuse V1ResponseError
+   */
+  app.post(
+    apiUrl + "/:devicename",
+    [
+      auth.authenticateUser,
+      middleware.getDevice(param),
+      auth.userCanAccessDevices
+    ],
+    middleware.requestWrapper(recordingUtil.makeUploadHandler())
+  );
+
+  /**
    * @api {get} /api/v1/recordings Query available recordings
    * @apiName QueryRecordings
    * @apiGroup Recordings

--- a/test/helper.py
+++ b/test/helper.py
@@ -113,6 +113,7 @@ class Helper:
 
         if not group:
             group = self.config.default_group
+
         device = DeviceAPI(self.config.api_url, uniqueName, self._make_password(uniqueName)).register_as_new(
             group
         )

--- a/test/test_device_query.py
+++ b/test/test_device_query.py
@@ -31,7 +31,7 @@ class TestDeviceQuery:
 
         devices = clare.query_devices(groups=[gary_group])
         ids = set([device["id"] for device in devices])
-        assert ids == set()
+        assert not ids
 
         devices = gary.query_devices(devices=[terminator], groups=[gary_group, clares_group])
         ids = set([device["id"] for device in devices])
@@ -51,8 +51,8 @@ class TestDeviceQuery:
         access = {"devices": "r"}
         clare.new_token(access, set_token=True)
         devices = clare.query_devices(devices=[terminator, terminator2])
-        ids = [device["id"] for device in devices]
-        assert ids == [terminator.get_id(), terminator2.get_id()]
+        ids = set([device["id"] for device in devices])
+        assert ids == set([terminator.get_id(), terminator2.get_id()])
         new_group = helper.make_unique_group_name(self, "clares_group")
         with pytest.raises(AuthenticationError):
             clare.create_group(new_group)
@@ -60,7 +60,7 @@ class TestDeviceQuery:
         devices = clare.query_devices(
             devices=[terminator, terminator2], groups=[clares_group], operator="AND"
         )
-        ids = [device["id"] for device in devices]
-        assert ids == [terminator.get_id(), terminator2.get_id()]
+        ids = set(device["id"] for device in devices)
+        assert ids == set([terminator.get_id(), terminator2.get_id()])
         with pytest.raises(UnprocessableError):
             devices = clare.query_devices(devices=[terminator, terminator2], operator="in")

--- a/test/test_user_thermal.py
+++ b/test/test_user_thermal.py
@@ -67,3 +67,36 @@ class TestUserThermal:
 
         print("\nNor be able to see the recording through the audio query API")
         user.cannot_see_audio_recording(recording)
+
+    def test_can_upload_recording_for_device_legacy(self, helper):
+        data_collector, device = helper.given_new_user_with_device(self, "data_collector")
+        print("   and data_collector uploads a recording on behalf of the device")
+        recording = data_collector.legacy_uploads_recording_for(device)
+        print("Then an super user should be able to download the recording")
+        helper.admin_user().can_download_correct_recording(recording)
+
+    def test_must_have_permission_to_upload_recording_for_device_legacy(self, helper):
+        device = helper.given_new_device(self, "random_device")
+
+        print("    and an unrelated user 'trouble'", end="")
+        trouble = helper.given_new_user(self, "trouble")
+
+        print("Then 'trouble' should not be able to upload a recording on the behalf of the device.")
+        with pytest.raises(AuthorizationError):
+            trouble.legacy_uploads_recording_for(device)
+
+    @pytest.mark.skip(reason="Enable when group+device uniqueness implemented")
+    def test_upload_recording_for_legacy_duplicate(self, helper):
+        user = helper.given_new_user(self, "someone")
+
+        # Create two devices with the same name in different groups
+        device_name = helper.random_id(length=30)
+
+        group_name0 = helper.make_unique_group_name(self, "someone0")
+        group0 = user.create_group(group_name0)
+        helper.given_new_device(None, devicename=device_name, group=group0)
+
+        group_name1 = helper.make_unique_group_name(self, "someone1")
+        group1 = user.create_group(group_name1)
+        device1 = helper.given_new_device(None, devicename=device_name, group=group1)
+        user.legacy_uploads_recording_for(device1)

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -319,6 +319,16 @@ class TestUser:
 
         return Recording(recording_id, props, filename)
 
+    def legacy_uploads_recording_for(self, testdevice):
+        props = testdevice.get_new_recording_props()
+        filename = "files/small.cptv"
+        recording_id = self._userapi.legacy_upload_recording_for(testdevice.devicename, filename, props)
+
+        # Expect to see this in data returned by the API server.
+        props["rawMimeType"] = "application/x-cptv"
+
+        return Recording(recording_id, props, filename)
+
     def set_global_permission(self, user, permission):
         self._userapi.set_global_permission(user, permission)
 

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -334,6 +334,12 @@ class UserAPI(APIBase):
             endpoint += "/group/{}".format(groupname)
         return self._upload("/api/v1/recordings/{}".format(endpoint), filename, props)
 
+    def legacy_upload_recording_for(self, devicename, filename, props=None):
+        print("legacy_upload_recording_for:", devicename)
+        if not props:
+            props = {"type": "thermalRaw"}
+        return self._upload("/api/v1/recordings/{}".format(devicename), filename, props)
+
     def set_global_permission(self, user, permission):
         url = urljoin(self._baseurl, "/api/v1/admin/global_permission/" + user)
         response = requests.patch(url, headers=self._auth_header, data={"permission": permission})


### PR DESCRIPTION
This is still be used by Sidekick in the wild so we need to support it for a little longer.

Also fixed sporadically failing device query tests.
