### PR TITLE
Ensure that cacophony-api-remove-dups isn't group writeable

### DIFF
--- a/_release/build.sh
+++ b/_release/build.sh
@@ -29,9 +29,9 @@ cp _release/* ${build_dir}/_release  # makes things easier while developing rele
 
 cd ${build_dir}
 
-# cron doesn't like it when this is writeable by anyone other than the
+# cron doesn't like it when cron.d files are writeable by anyone other than the
 # owner.
-chmod 644 _release/cacophony-api-prune-objects
+chmod 644 _release/{cacophony-api-prune-objects,cacophony-api-remove-dups}
 
 echo "Setting versions..."
 perl -pi -e "s/^version:.+/version: \"${version}\"/" _release/nfpm.yaml


### PR DESCRIPTION
This file was being deployed as writeable meaning that cron wasn't
running it.