### PR TITLE
Add additional CORS Access-Control-Allow-Headers that are standard

### DIFF
--- a/Server.js
+++ b/Server.js
@@ -47,7 +47,7 @@ app.all("*", function(req, res, next) {
   );
   res.header(
     "Access-Control-Allow-Headers",
-    "where, offset, limit, Authorization"
+    "where, offset, limit, Authorization, Origin, X-Requested-With, Content-Type, Accept"
   );
   next();
 });


### PR DESCRIPTION
This will allow Cacophony Browse to use JSON objects instead of url encoding.

The added headers are standard ones that are basically always enabled as seen below and on numerous other guides about CORS
https://enable-cors.org/server_expressjs.html

The one we really care about is Content-Type so we can send JSON.

#199 and #207 rely on this fix to get Cacophony Browse in spec as it currently used form encoding which is messier and less flexible.