### PR TITLE
Set longer request timeout for report endpoint

### DIFF
--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -217,6 +217,10 @@ module.exports = (app, baseUrl) => {
     apiUrl + "/report",
     [auth.paramOrHeader].concat(queryValidators),
     middleware.requestWrapper(async (request, response) => {
+      // 10 minute timeout because the query can take a while to run
+      // when the result set is large.
+      // See also: ttps://trello.com/c/KYnPlpYq/287-query-for-csv-export-is-slow
+      request.setTimeout(10 * 60 * 1000);
       const rows = await recordingUtil.report(request);
       response.status(200).set({
         "Content-Type": "text/csv",


### PR DESCRIPTION
The query can take a long time and exceed Express' default 2min
timeout. We will improve the query but this will do in the mean time.