### PR TITLE
Remove now unused conversion from data field to body

### DIFF
--- a/api/V1/User.js
+++ b/api/V1/User.js
@@ -95,21 +95,6 @@ module.exports = function(app, baseUrl) {
     apiUrl,
     [
       auth.authenticateUser,
-      (req, _, next) => {
-        // Deprecated, legacy support until consumers migrated see #199 on GitHub
-        if (typeof req.body.data === "string") {
-          try {
-            const json = JSON.parse(req.body.data);
-            req.body.email = json.email;
-            req.body.username = json.username;
-            req.body.password = json.password;
-            req.body.endUserAgreement = json.endUserAgreement;
-          } catch (e) {
-            throw new ClientError("Could not parse JSON in data field.");
-          }
-        }
-        next();
-      },
       middleware
         .checkNewName("username")
         .custom(value => {


### PR DESCRIPTION
Fixes #199, Fixes #207 

The final work to remove the string JSON fields. The PATCH users endpoint is only used by Cacophony Browse and it's now using the real JSON, so we can now remove this converter.

The rest of the endpoints support both ways, and that's probably the best way to leave them, as then we don't have to double check everything's migrated, but any new consumers, as well as Cacophony Browse, can do it the cleaner way.