### PR TITLE
Fix 38 & 130, delete recording files from S3 when recording is deleted, and dont return JWTs if files don't exist

### DIFF
--- a/api/V1/File.js
+++ b/api/V1/File.js
@@ -133,15 +133,11 @@ module.exports = (app, baseUrl) => {
         key: file.fileKey
       };
 
-      const s3Data = await util.getS3Object(file.fileKey).catch(err => {
-        return responseUtil.serverError(response, err);
-      });
-
       return responseUtil.send(response, {
         statusCode: 200,
         messages: [],
         file: file,
-        fileSize: s3Data.ContentLength,
+        fileSize: await util.getS3ObjectFileSize(file.fileKey),
         jwt: jsonwebtoken.sign(downloadFileData, config.server.passportSecret, {
           expiresIn: 60 * 10
         })

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -292,6 +292,9 @@ async function get(request, type) {
     data.rawSize = await util.getS3ObjectFileSize(recording.rawFileKey);
   }
 
+  delete data.recording.rawFileKey;
+  delete data.recording.fileKey;
+
   return data;
 }
 

--- a/api/V1/recordingUtil.js
+++ b/api/V1/recordingUtil.js
@@ -23,7 +23,6 @@ const urljoin = require("url-join");
 
 const { ClientError } = require("../customErrors");
 const config = require("../../config");
-const log = require("../../logging");
 const models = require("../../models");
 const responseUtil = require("./responseUtil");
 const util = require("./util");
@@ -246,67 +245,37 @@ async function get(request, type) {
     throw new ClientError("No file found with given datapoint.");
   }
 
-  const downloadFileData = {
-    _type: "fileDownload",
-    key: recording.fileKey,
-    filename: recording.getFileName(),
-    mimeType: recording.fileMimeType
+  const data = {
+    recording: handleLegacyTagFieldsForGetOnRecording(recording)
   };
 
-  const downloadRawData = {
-    _type: "fileDownload",
-    key: recording.rawFileKey,
-    filename: recording.getRawFileName(),
-    mimeType: recording.rawMimeType
-  };
-
-  let rawSize = null;
-  if (recording.rawFileKey) {
-    await util
-      .getS3Object(recording.rawFileKey)
-      .then(rawS3Data => {
-        rawSize = rawS3Data.ContentLength;
-      })
-      .catch(err => {
-        log.warn(
-          "Error retrieving S3 Object for recording",
-          err.message,
-          recording.rawFileKey
-        );
-      });
-  }
-
-  let cookedSize = null;
   if (recording.fileKey) {
-    await util
-      .getS3Object(recording.fileKey)
-      .then(s3Data => {
-        cookedSize = s3Data.ContentLength;
-      })
-      .catch(err => {
-        log.warn(
-          "Error retrieving S3 Object for recording",
-          err.message,
-          recording.fileKey
-        );
-      });
+    data.cookedJWT = jsonwebtoken.sign({
+      _type: "fileDownload",
+      key: recording.fileKey,
+      filename: recording.getFileName(),
+      mimeType: recording.fileMimeType
+    },
+    config.server.passportSecret,
+    { expiresIn: 60 * 10 }
+    );
+    data.cookedSize = await util.getS3ObjectFileSize(recording.fileKey);
   }
 
-  delete recording.rawFileKey;
+  if (recording.rawFileKey) {
+    data.rawJWT = jsonwebtoken.sign({
+      _type: "fileDownload",
+      key: recording.rawFileKey,
+      filename: recording.getRawFileName(),
+      mimeType: recording.rawMimeType
+    },
+    config.server.passportSecret,
+    { expiresIn: 60 * 10 }
+    );
+    data.rawSize = await util.getS3ObjectFileSize(recording.rawFileKey);
+  }
 
-  return {
-    recording: handleLegacyTagFieldsForGetOnRecording(recording),
-    cookedSize: cookedSize,
-    cookedJWT: jsonwebtoken.sign(
-      downloadFileData,
-      config.server.passportSecret,
-      { expiresIn: 60 * 10 }
-    ),
-    rawSize: rawSize,
-    rawJWT: jsonwebtoken.sign(downloadRawData, config.server.passportSecret, {
-      expiresIn: 60 * 10
-    })
-  };
+  return data;
 }
 
 async function delete_(request, response) {

--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -137,6 +137,16 @@ async function getS3ObjectFileSize(fileKey) {
   }
 }
 
+async function deleteS3Object(fileKey) {
+  const s3 = modelsUtil.openS3();
+  const params = {
+    Bucket: config.s3.bucket,
+    Key: fileKey
+  };
+  return s3.deleteObject(params).promise();
+}
+
 exports.getS3Object = getS3Object;
 exports.getS3ObjectFileSize = getS3ObjectFileSize;
+exports.deleteS3Object = deleteS3Object;
 exports.multipartUpload = multipartUpload;

--- a/api/V1/util.js
+++ b/api/V1/util.js
@@ -128,5 +128,15 @@ function getS3Object(fileKey) {
   return s3.headObject(params).promise();
 }
 
+async function getS3ObjectFileSize(fileKey) {
+  try {
+    const s3Ojb = await getS3Object(fileKey);
+    return s3Ojb.ContentLength;
+  } catch (err) {
+    log.warn(`Error retrieving S3 Object for with fileKey: ${fileKey}. Error was: ${err.message}`);
+  }
+}
+
 exports.getS3Object = getS3Object;
+exports.getS3ObjectFileSize = getS3ObjectFileSize;
 exports.multipartUpload = multipartUpload;

--- a/models/Recording.js
+++ b/models/Recording.js
@@ -198,14 +198,15 @@ module.exports = function(sequelize, DataTypes) {
 
   /**
    * Deletes a single recording if the user has permission to do so.
+   * @returns {Promise<Recording|null>} Returns the recording object if deleted, otherwise null.
    */
   Recording.deleteOne = async function(user, id) {
     const recording = await Recording.get(user, id, Recording.Perms.DELETE);
     if (!recording) {
-      return false;
+      return null;
     }
     await recording.destroy();
-    return true;
+    return recording;
   };
 
   /**

--- a/test/recording.py
+++ b/test/recording.py
@@ -19,6 +19,9 @@ class Recording:
     def __setitem__(self, name, value):
         self.props[name] = value
 
+    def __iter__(self):
+        return iter(self.props)
+
     def is_tagged_as(self, **data):
         return TagPromise(self, data)
 

--- a/test/test_audio_device.py
+++ b/test/test_audio_device.py
@@ -15,7 +15,7 @@ class TestAudioDevice:
         user.can_download_correct_recording(recording)
 
     def test_can_only_set_user_settable_fields(self, helper):
-        UNSETTABLE_FIELD = "fileKey"
+        UNSETTABLE_FIELD = "GroupId"
         UNSETTABLE_INPUT_VALUE = "test_value"
 
         description = "If a new device 'Listener' signs up"

--- a/test/test_file_processing.py
+++ b/test/test_file_processing.py
@@ -11,7 +11,8 @@ class TestFileProcessing:
         if recording is not None:
             assert recording["processingState"] == "getMetadata"
             assert recording["processingStartTime"] is not None
-            assert recording["rawFileKey"] is not None
+            assert "rawFileKey" in recording
+            assert "fileKey" in recording
 
         return recording
 

--- a/test/test_file_processing.py
+++ b/test/test_file_processing.py
@@ -11,6 +11,7 @@ class TestFileProcessing:
         if recording is not None:
             assert recording["processingState"] == "getMetadata"
             assert recording["processingStartTime"] is not None
+            assert recording["rawFileKey"] is not None
 
         return recording
 
@@ -254,7 +255,10 @@ class TestFileProcessing:
 
         # Now finalise processing.
         file_processing.put(recording, success=True, complete=True, new_object_key="some_key")
-        check_recording(admin, recording, processingState="FINISHED")
+        query_result = admin.query_recordings(
+            where={"id": recording.id_, "fileKey": "some_key", "processingState": "FINISHED"}
+        )
+        assert len(query_result) == 1
 
         track, tag = self.add_tracks_and_tag(file_processing, recording)
         admin.can_see_track(track)

--- a/test/test_file_processing.py
+++ b/test/test_file_processing.py
@@ -254,7 +254,7 @@ class TestFileProcessing:
 
         # Now finalise processing.
         file_processing.put(recording, success=True, complete=True, new_object_key="some_key")
-        check_recording(admin, recording, processingState="FINISHED", fileKey="some_key")
+        check_recording(admin, recording, processingState="FINISHED")
 
         track, tag = self.add_tracks_and_tag(file_processing, recording)
         admin.can_see_track(track)

--- a/test/test_recordings.py
+++ b/test/test_recordings.py
@@ -30,5 +30,6 @@ class TestRecordings:
         print("And then fetches it")
         recording_response = bob.get_recording(recording)
 
-        print("  The recording response should not contain the rawFileKey")
+        print("  The recording response should not contain the fileKeys")
         assert "rawFileKey" not in recording_response
+        assert "fileKey" not in recording_response

--- a/test/test_recordings.py
+++ b/test/test_recordings.py
@@ -1,0 +1,20 @@
+import pytest
+import json
+
+
+class TestRecordings:
+    def test_unprocessed_recording_doesnt_return_processed_jwt(self, helper):
+        print("If a new user uploads a recording")
+        bob = helper.given_new_user(self, "bob_limit")
+        bobsGroup = helper.make_unique_group_name(self, "bobs_group")
+        bob.create_group(bobsGroup)
+        bobsDevice = helper.given_new_device(self, "bobs_device", bobsGroup)
+        recording = bobsDevice.upload_recording()
+
+        print("And then fetches it before it has been processed")
+        response = bob.get_recording_response(recording)
+
+        print("  The response should have a JWT for the raw file")
+        assert "downloadRawJWT" in response
+        print("  But the response should not have a JWT for the processed file")
+        assert "downloadFileJWT" not in response

--- a/test/test_recordings.py
+++ b/test/test_recordings.py
@@ -18,3 +18,17 @@ class TestRecordings:
         assert "downloadRawJWT" in response
         print("  But the response should not have a JWT for the processed file")
         assert "downloadFileJWT" not in response
+
+    def test_recording_doesnt_include_file_key(self, helper):
+        print("If a new user uploads a recording")
+        bob = helper.given_new_user(self, "bob_limit")
+        bobsGroup = helper.make_unique_group_name(self, "bobs_group")
+        bob.create_group(bobsGroup)
+        bobsDevice = helper.given_new_device(self, "bobs_device", bobsGroup)
+        recording = bobsDevice.upload_recording()
+
+        print("And then fetches it")
+        recording_response = bob.get_recording(recording)
+
+        print("  The recording response should not contain the rawFileKey")
+        assert "rawFileKey" not in recording_response

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -50,6 +50,9 @@ class TestUser:
     def get_recording(self, recording, params=None):
         return self._userapi.get_recording(recording.id_, params)
 
+    def get_recording_response(self, recording, params=None):
+        return self._userapi.get_recording_response(recording.id_, params)
+
     def query_recordings(self, **options):
         return self._userapi.query(**options)
 

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -162,10 +162,8 @@ class TestUser:
         del recv_props["Tags"]
         del recv_props["GroupId"]
         del recv_props["location"]
-        del recv_props["rawFileKey"]
         if "rawMimeType" not in props:
             del recv_props["rawMimeType"]
-        del recv_props["fileKey"]
         del recv_props["fileMimeType"]
         if "type" not in props:
             recv_props.pop("type", None)

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -55,8 +55,10 @@ class UserAPI(APIBase):
         filterOptions=None,
         deviceIds=None,
         return_json=False,
+        where=None,
     ):
-        where = defaultdict(dict)
+        if where is None:
+            where = defaultdict(dict)
         where["duration"] = {"$gte": min_secs}
         if startDate is not None:
             where["recordingDateTime"]["$gte"] = startDate.isoformat()


### PR DESCRIPTION
Fixes #38, Fixes #130

#38 
Update Recording delete to also delete the S3 files in the background.
Will log a warning if it wasn't deleted but will still return 200 before that results and no matter the status of the S3 deletions.
Didn't add a test for this but you can verify with minio/mc, create recording, GET it and note the rawFileKey, configure mc if you haven't already: `mc config host add s3 http://localhost:9001 minio miniostorage `, then query the file such as `mc ls s3/cacophony/raw/2019/12/19/c4b2b587-a463-45e6-a499-40b95bd25c1b`, should return the file and size. Delete the file through UI. Run the mc ls command again and the it should say file not found.

#130 
Update recording JWTs to only apply if the file exists
Extracted out a method to get the filesize of files in S3 to simplify code.
Consumers will have to check for the existence of the field now, although Cacophony Browse currently seems to behave the same with or without this change.
Added a test for this.