### PR TITLE
Fix Recording GET order example

### DIFF
--- a/api/V1/Recording.js
+++ b/api/V1/Recording.js
@@ -177,6 +177,7 @@ module.exports = (app, baseUrl) => {
    *
    * @apiUse V1UserAuthorizationHeader
    * @apiUse BaseQueryParams
+   * @apiUse RecordingOrder
    * @apiUse MoreQueryParams
    * @apiUse FilterOptions
    * @apiUse V1ResponseSuccessQuery
@@ -209,6 +210,7 @@ module.exports = (app, baseUrl) => {
    * @apiUse V1UserAuthorizationHeader
    * @apiParam {String} [jwt] Signed JWT as produced by the [Token](#api-Authentication-Token) endpoint
    * @apiUse BaseQueryParams
+   * @apiUse RecordingOrder
    * @apiUse MoreQueryParams
    * @apiUse FilterOptions
    * @apiUse V1ResponseError

--- a/api/V1/apidoc.js
+++ b/api/V1/apidoc.js
@@ -37,9 +37,13 @@
  * to match { "details": {"name": "sample"}}.  Note: Only some embeded keys will work.
  * @apiParam {Number} [offset] Zero-based page number. Use '0' to get the first page.  Each page has 'limit' number of records.
  * @apiParam {Number} [limit] Max number of records to be returned.
- * @apiParam {JSON} [order] Sorting order for records.
- * * For example, ["dateTime"] or [["dateTime", "ASC"]].
  */
+
+/**
+  * @apiDefine RecordingOrder
+  * @apiParam {JSON} [order] Sorting order for records.
+  * * For example, ["recordingDateTime"] or [["recordingDateTime", "ASC"]].
+*/
 
 /**
  * @apiDefine MoreQueryParams


### PR DESCRIPTION
- Changed from `dateTime` to `recordingDateTime`
- Separated out Order from `BaseQueryParams` as `BaseQueryParams` is used in the `Files` API documentation where the order example is not relevant.