### PR TITLE
Restore GroupUsers to unbreak groups admin view

### DIFF
--- a/models/Group.ts
+++ b/models/Group.ts
@@ -141,6 +141,10 @@ export default function(sequelize, DataTypes): GroupStatic {
       include: [
         {
           model: models.User,
+          // NOTE(jon): This adds GroupUsers to the group, which is currently required
+          // by the groups admin view to add new users to groups.  As per
+          // https://github.com/TheCacophonyProject/cacophony-api/issues/279
+          // we'd like to split this out into separate requests probably.
           attributes: ['id', 'username'],
           where: userWhere
         },

--- a/models/Group.ts
+++ b/models/Group.ts
@@ -141,7 +141,7 @@ export default function(sequelize, DataTypes): GroupStatic {
       include: [
         {
           model: models.User,
-          attributes: [],
+          attributes: ['id', 'username'],
           where: userWhere
         },
         {


### PR DESCRIPTION
I stopped group users from being bundled with getting groups, but it turns out some front-end views were relying on that.  Put it back for now and explore better solutions in the future?