### PR TITLE
Avoid systemctl pager usage in postinstall script

### DIFF
--- a/_release/postinstall.sh
+++ b/_release/postinstall.sh
@@ -39,4 +39,4 @@ npm run apidoc
 section "Restarting API server"
 systemctl daemon-reload
 systemctl start cacophony-api
-systemctl status cacophony-api
+systemctl --no-pager status cacophony-api


### PR DESCRIPTION
Without this the postinstall script can pause waiting for the pager to end. This is confusing to the user.