### PR TITLE
Add system err event

### DIFF
--- a/api/V1/Schedule.ts
+++ b/api/V1/Schedule.ts
@@ -142,6 +142,10 @@ async function getSchedule(device: any, response: Response, user = null) {
     resData.devices = await models.Device.onlyUsersDevicesMatching(user, {
       ScheduleId: device.ScheduleId
     });
+  } else if (user) {
+    resData.devices = await models.Device.onlyUsersDevicesMatching(user, {
+      id: device.id
+    });
   }
   return responseUtil.send(response, resData);
 }

--- a/models/DetailSnapshot.ts
+++ b/models/DetailSnapshot.ts
@@ -27,7 +27,7 @@ export interface DetailSnapShot
     ModelCommon<DetailSnapShot> {
   getFile: () => Promise<File>;
   id: DetailSnapshotId;
-  type: "algorithm" | "throttle" | "audioBait";
+  type: "algorithm" | "throttle" | "audioBait" | "systemError";
   details: any; // JSON
 }
 
@@ -79,7 +79,9 @@ export default function(sequelize, DataTypes): DetailSnapshotStatic {
     const existing = await this.findOne({
       where: {
         type: searchType,
-        details: searchDetails
+        details: {
+          [Op.eq]: searchDetails,   // Need to specify the equal operator as it's a JSONB
+        },
       }
     });
 


### PR DESCRIPTION
- Make the `devices` field always set when getting schedule. Fixes a error in cacophony-browse-old where you couldn't add a schedule to a device that didn't already have a schedule set.


- Specify sequelise to use equals when comparing the details JSONB for a event. 
When not set this is an example of the SQL generated 
`AND (CAST(("DetailSnapshot"."details"#>>\'{foo}\') AS DOUBLE PRECISION) = ARRAY[1,2,3] AND CAST(("DetailSnapshot"."details"#>>\'{test2}\') AS DOUBLE PRECISION) = 2)`
Resulting in `SequelizeDatabaseError: operator does not exist: double precision = integer[]`