### PR TITLE
Added delay between getting keys from object store and DB

### DIFF
--- a/prune-objects.ts
+++ b/prune-objects.ts
@@ -36,6 +36,9 @@ async function main() {
   );
   console.log(`loaded ${bucketKeys.size} keys from the object store`);
 
+  console.log("waiting 20 minutes before getting keys from database to give uploading recordings time to finish");
+  await new Promise(r => setTimeout(r, 1000*60*20)); // Sleep 20 minutes
+  console.log("getting keys from the database");
   const dbKeys = await loadAllDBKeys(pgClient, keyTypes);
   console.log(`${dbKeys.size} keys loaded from the database`);
 


### PR DESCRIPTION
When recordings are uploaded they are added to the object store then when finished uploading they are added to the database. This delay is to prevent recordings getting deleted as they are in the processing of uploading.