### PR TITLE
Add user event upload

### DIFF
--- a/api/V1/Event.ts
+++ b/api/V1/Event.ts
@@ -31,20 +31,16 @@ export default function(app: Application, baseUrl: string) {
    * @api {post} /api/v1/events Add new events
    * @apiName Add Event
    * @apiGroup Events
-   * @apiDescription This call is used to upload new events.   Events
-   * details are decided by user and can be specified by JSON or using an
-   * existing id.
+   * @apiDescription This call is used to upload new events.
+   * The event can be described by specifying an existing eventDetailId or by
+   * the 'description' parameter.
    *
    * `Either eventDetailId or description is required`
-   * - eventDetailsId: id
-   * - description:
-   *   - type:
-   *   - details: {JSON}
-   * - datetimes: REQUIRED: array of event times in ISO standard format, eg ["2017-11-13T00:47:51.160Z"]
-   *
    * @apiUse V1DeviceAuthorizationHeader
    *
-   * @apiParam {JSON} data Metadata about the recording (see above).
+   * @apiUse EventParams
+   * @apiUse EventExampleDescription
+   * @apiUse EventExampleEventDetailId
    *
    * @apiUse V1ResponseSuccess
    * @apiSuccess {Integer} eventsAdded Number of events added
@@ -65,20 +61,16 @@ export default function(app: Application, baseUrl: string) {
    * @apiName AddEventOnBehalf
    * @apiGroup Events
    * @apiDescription This call is used to upload new events on behalf of a device.
-   * Events details are decided by user and can be specified by JSON or using an
-   * existing id.
+   * The event can be described by specifying an existing eventDetailId or by
+   * the 'description' parameter.
    *
    * `Either eventDetailId or description is required`
-   * - eventDetailsId: id
-   * - description:
-   *   - type:
-   *   - details: {JSON}
-   * - datetimes: REQUIRED: array of event times in ISO standard format, eg ["2017-11-13T00:47:51.160Z"]
-   *
    * @apiParam {String} deviceID ID of the device to upload on behalf of. If you don't have access to the ID the devicename can be used instead in it's place.
    * @apiUse V1UserAuthorizationHeader
    *
    * @apiUse EventParams
+   * @apiUse EventExampleDescription
+   * @apiUse EventExampleEventDetailId
    *
    * @apiUse V1ResponseSuccess
    * @apiSuccess {Integer} eventsAdded Number of events added

--- a/api/V1/Event.ts
+++ b/api/V1/Event.ts
@@ -20,8 +20,9 @@ import middleware from "../middleware";
 import auth from "../auth";
 import models from "../../models";
 import responseUtil from "./responseUtil";
-import { body, oneOf, query } from "express-validator/check";
+import { param, body, oneOf, query } from "express-validator/check";
 import { Application } from "express";
+import eventUtil from "./eventUtil";
 
 export default function(app: Application, baseUrl: string) {
   const apiUrl = `${baseUrl}/events`;
@@ -54,55 +55,46 @@ export default function(app: Application, baseUrl: string) {
     apiUrl,
     [
       auth.authenticateDevice,
-      middleware.getDetailSnapshotById(body, "eventDetailId").optional(),
-      middleware.isDateArray(
-        "dateTimes",
-        "List of times event occured is required."
-      ),
-      oneOf(
-        [body("eventDetailId").exists(), body("description.type").exists()],
-        "Either 'eventDetailId' or 'description.type' must be specified."
-      )
+      ...eventUtil.eventAuth
     ],
-    middleware.requestWrapper(async (request, response) => {
-      let detailsId = request.body.eventDetailId;
-      if (!detailsId) {
-        const description = request.body.description;
-        const detail = await models.DetailSnapshot.getOrCreateMatching(
-          description.type,
-          description.details
-        );
-        detailsId = detail.id;
-      }
+    middleware.requestWrapper(eventUtil.uploadEvent)
+  );
 
-      const eventList = [];
-      let count = 0;
-
-      request.body.dateTimes.forEach(function(time) {
-        eventList.push({
-          DeviceId: request.device.id,
-          EventDetailId: detailsId,
-          dateTime: time
-        });
-        count++;
-      });
-
-      try {
-        await models.Event.bulkCreate(eventList);
-      } catch (exception) {
-        return responseUtil.send(response, {
-          statusCode: 500,
-          messages: ["Failed to record events.", exception.message]
-        });
-      }
-
-      return responseUtil.send(response, {
-        statusCode: 200,
-        messages: ["Added events."],
-        eventsAdded: count,
-        eventDetailId: detailsId
-      });
-    })
+  /**
+   * @api {post} /api/v1/events/device/:deviceID Add new events on behalf of device
+   * @apiName AddEventOnBehalf
+   * @apiGroup Events
+   * @apiDescription This call is used to upload new events on behalf of a device.
+   * Events details are decided by user and can be specified by JSON or using an
+   * existing id.
+   *
+   * `Either eventDetailId or description is required`
+   * - eventDetailsId: id
+   * - description:
+   *   - type:
+   *   - details: {JSON}
+   * - datetimes: REQUIRED: array of event times in ISO standard format, eg ["2017-11-13T00:47:51.160Z"]
+   * @apiUse EventDetailsDescription
+   *
+   * @apiParam {String} deviceID ID of the device to upload on behalf of. If you don't have access to the ID the devicename can be used instead in it's place.
+   * @apiUse V1UserAuthorizationHeader
+   *
+   * @apiUse EventParams
+   *
+   * @apiUse V1ResponseSuccess
+   * @apiSuccess {Integer} eventsAdded Number of events added
+   * @apiSuccess {Integer} eventDetailId Id of the Event Detail record used.  May be existing or newly created
+   * @apiuse V1ResponseError
+   */
+  app.post(
+    apiUrl+"/device/:deviceID",
+    [
+      auth.authenticateUser,
+      middleware.getDevice(param, "deviceID"),
+      auth.userCanAccessDevices,
+      ...eventUtil.eventAuth,
+    ],
+    middleware.requestWrapper(eventUtil.uploadEvent)
   );
 
   /**

--- a/api/V1/Event.ts
+++ b/api/V1/Event.ts
@@ -74,7 +74,6 @@ export default function(app: Application, baseUrl: string) {
    *   - type:
    *   - details: {JSON}
    * - datetimes: REQUIRED: array of event times in ISO standard format, eg ["2017-11-13T00:47:51.160Z"]
-   * @apiUse EventDetailsDescription
    *
    * @apiParam {String} deviceID ID of the device to upload on behalf of. If you don't have access to the ID the devicename can be used instead in it's place.
    * @apiUse V1UserAuthorizationHeader

--- a/api/V1/Schedule.ts
+++ b/api/V1/Schedule.ts
@@ -142,6 +142,10 @@ async function getSchedule(device: any, response: Response, user = null) {
     resData.devices = await models.Device.onlyUsersDevicesMatching(user, {
       ScheduleId: device.ScheduleId
     });
+  } else if (user) {
+    resData.devices = await models.Device.onlyUsersDevicesMatching(user, {
+      id: device.id
+    });
   }
   return responseUtil.send(response, resData);
 }

--- a/api/V1/apidoc.js
+++ b/api/V1/apidoc.js
@@ -86,17 +86,6 @@
  * </ul>
  */
 
-/**
- * @apiDefine EventDetailsDescription
- * `Either eventDetailId or description is required`
- * - eventDetailsId: id
- * - description:
- *   - type:
- *   - details: {JSON}
- * - datetimes: REQUIRED: array of event times in ISO standard format, eg ["2017-11-13T00:47:51.160Z"]
- */
-
-
  /**
   * @apiDefine EventParams
   * @apiParam {JSON} data Metadata about the recording (see above).

--- a/api/V1/apidoc.js
+++ b/api/V1/apidoc.js
@@ -88,5 +88,30 @@
 
 /**
  * @apiDefine EventParams
- * @apiParam {JSON} data Metadata about the recording (see above).
+ * @apiParam {JSON} [description] JSON of the event. Must be used if the if you don't give the eventDetailId
+ * @apiParam {String} [description.type] Name of the type of event.
+ * @apiParam {JSON} [description.details] Metadata of the event.
+ * @apiParam {JSON} [eventDetailId] ID of the event details if known.
+ * @apiParam {Array} dateTimes Array of event times in ISO standard format, eg ["2017-11-13T00:47:51.160Z"]
  */
+
+/**
+ * @apiDefine EventExampleDescription
+ * @apiParamExample {json} Using description:
+ *  {
+ *    "description": {
+ *      "type": "example"
+ *      "details": {"foo": "bar"},
+ *    },
+ *    "dateTimes": ["2017-11-13T00:47:51.160Z"]
+ *  }
+*/
+
+/**
+ * @apiDefine EventExampleEventDetailId
+ * @apiParamExample {json} Using eventDetailId:
+ *  {
+ *    "eventDetailId": 1,
+ *    "dateTimes": ["2017-11-13T00:47:51.160Z"]
+ *  }
+*/

--- a/api/V1/apidoc.js
+++ b/api/V1/apidoc.js
@@ -85,3 +85,19 @@
  * <li>latLongPrec: Maximum precision of latitude longitude coordinates in meters. Minimum 100m
  * </ul>
  */
+
+/**
+ * @apiDefine EventDetailsDescription
+ * `Either eventDetailId or description is required`
+ * - eventDetailsId: id
+ * - description:
+ *   - type:
+ *   - details: {JSON}
+ * - datetimes: REQUIRED: array of event times in ISO standard format, eg ["2017-11-13T00:47:51.160Z"]
+ */
+
+
+ /**
+  * @apiDefine EventParams
+  * @apiParam {JSON} data Metadata about the recording (see above).
+  */

--- a/api/V1/apidoc.js
+++ b/api/V1/apidoc.js
@@ -86,7 +86,7 @@
  * </ul>
  */
 
- /**
-  * @apiDefine EventParams
-  * @apiParam {JSON} data Metadata about the recording (see above).
-  */
+/**
+ * @apiDefine EventParams
+ * @apiParam {JSON} data Metadata about the recording (see above).
+ */

--- a/api/V1/eventUtil.ts
+++ b/api/V1/eventUtil.ts
@@ -1,0 +1,61 @@
+import middleware from "../middleware";
+import models from "../../models";
+import responseUtil from "./responseUtil";
+import { body, oneOf } from "express-validator/check";
+
+async function uploadEvent(request, response) {
+  let detailsId = request.body.eventDetailId;
+  if (!detailsId) {
+    const description = request.body.description;
+    const detail = await models.DetailSnapshot.getOrCreateMatching(
+      description.type,
+      description.details
+    );
+    detailsId = detail.id;
+  }
+
+  const eventList = [];
+  let count = 0;
+
+  request.body.dateTimes.forEach(function(time) {
+    eventList.push({
+      DeviceId: request.device.id,
+      EventDetailId: detailsId,
+      dateTime: time
+    });
+    count++;
+  });
+
+  try {
+    await models.Event.bulkCreate(eventList);
+  } catch (exception) {
+    return responseUtil.send(response, {
+      statusCode: 500,
+      messages: ["Failed to record events.", exception.message]
+    });
+  }
+
+  return responseUtil.send(response, {
+    statusCode: 200,
+    messages: ["Added events."],
+    eventsAdded: count,
+    eventDetailId: detailsId
+  });
+}
+
+const eventAuth = [
+  middleware.getDetailSnapshotById(body, "eventDetailId").optional(),
+  middleware.isDateArray(
+    "dateTimes",
+    "List of times event occured is required."
+  ),
+  oneOf(
+    [body("eventDetailId").exists(), body("description.type").exists()],
+    "Either 'eventDetailId' or 'description.type' must be specified."
+  ),
+];
+
+export default {
+  eventAuth,
+  uploadEvent,
+};

--- a/api/V1/index.ts
+++ b/api/V1/index.ts
@@ -26,6 +26,7 @@ export default function(app: Application) {
     "util.js",
     "responseUtil.js",
     "recordingUtil.js",
+    "eventUtil.js",
     "apidoc.js"
   ];
   // Filter out files that are not added to app directly, and filter out typescript versions of files.

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -28,11 +28,11 @@ class TestEvent:
     def test_can_upload_event_for_device(self, helper):
         data_collector, device = helper.given_new_user_with_device(self, "data_collector")
 
-        #check there are no events on this device
+        # check there are no events on this device
         data_collector.cannot_see_events()
 
         print("   and data_collector uploads a event on behalf of the device")
-        eventid = data_collector.record_event(device, "test", {"foo":"bar"})
+        eventid = data_collector.record_event(device, "test", {"foo": "bar"})
 
         print("Then 'data_collector' should be able to see that the device has an event")
         assert len(data_collector.can_see_events()) == 1
@@ -46,7 +46,7 @@ class TestEvent:
 
         print("And should not be able to upload events for a device")
         with pytest.raises(AuthorizationError):
-            user_without_device.record_event(device, "test2", {"foo2":"bar2"})
+            user_without_device.record_event(device, "test2", {"foo2": "bar2"})
 
     def test_devices_share_events(self, helper):
         shaker = helper.given_new_device(self, "The Shaker")

--- a/test/testuser.py
+++ b/test/testuser.py
@@ -336,6 +336,9 @@ class TestUser:
 
         return Recording(recording_id, props, filename)
 
+    def record_event(self, device, type_, details, times=None):
+        return self._userapi.record_event(device, type_, details, times)
+
     def set_global_permission(self, user, permission):
         self._userapi.set_global_permission(user, permission)
 

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -442,6 +442,19 @@ class UserAPI(APIBase):
         response = requests.delete(urljoin(self._baseurl, url), headers=self._auth_header,)
         return self._check_response(response)["messages"]
 
+    def record_event(self, device, type_, details, times=None):
+        data = {"description": {"type": type_, "details": details}}
+        return self.record_event_data(device, data, times)
+
+    def record_event_data(self, device, eventData, times=None):
+        if times is None:
+            times = [datetime.now()]
+        eventData["dateTimes"] = [t.isoformat() for t in times]
+        url = urljoin(self._baseurl, "/api/v1/events/device/"+str(device._id))
+
+        response = requests.post(url, headers=self._auth_header, json=eventData)
+        response_data = self._check_response(response)
+        return response_data["eventsAdded"], response_data["eventDetailId"]
 
 def serialise_params(params):
     out = {}

--- a/test/userapi.py
+++ b/test/userapi.py
@@ -450,11 +450,12 @@ class UserAPI(APIBase):
         if times is None:
             times = [datetime.now()]
         eventData["dateTimes"] = [t.isoformat() for t in times]
-        url = urljoin(self._baseurl, "/api/v1/events/device/"+str(device._id))
+        url = urljoin(self._baseurl, "/api/v1/events/device/" + str(device._id))
 
         response = requests.post(url, headers=self._auth_header, json=eventData)
         response_data = self._check_response(response)
         return response_data["eventsAdded"], response_data["eventDetailId"]
+
 
 def serialise_params(params):
     out = {}


### PR DESCRIPTION
Users can add events on behalf of devices same way that they can add recordings for devices.