### PR TITLE
Fix parseJSON middleware handling of json strings

### DIFF
--- a/api/middleware.ts
+++ b/api/middleware.ts
@@ -216,11 +216,15 @@ const parseJSON = function(
 ): ValidationChain {
   return checkFunc(field).custom((value, { req, location, path }) => {
     if (typeof req[location][path] === "string") {
-      try {
-        req[location][path] = JSON.parse(value);
-      } catch (e) {
-        throw new Error(format("Could not parse JSON field %s.", path));
+      let result = value;
+      while (typeof result !== "object") {
+        try {
+          result = JSON.parse(result);
+        } catch (e) {
+          throw new Error(format("Could not parse JSON field %s.", path));
+        }
       }
+      req[location][path] = result;
     }
     return req[location][path] !== undefined;
   });

--- a/api/middleware.ts
+++ b/api/middleware.ts
@@ -217,12 +217,15 @@ const parseJSON = function(
   return checkFunc(field).custom((value, { req, location, path }) => {
     if (typeof req[location][path] === "string") {
       let result = value;
-      while (typeof result !== "object") {
+      while (typeof result === "string") {
         try {
           result = JSON.parse(result);
         } catch (e) {
           throw new Error(format("Could not parse JSON field %s.", path));
         }
+      }
+      if (typeof result !== 'object') {
+        throw new Error(format("JSON field %s is not an object", path));
       }
       req[location][path] = result;
     }


### PR DESCRIPTION
This fixes the incorrect assumption that parsing a json string successfully always returns an object.
In reality it can be an object or literal which is stringified multiple times, and JSON.parse() will only unwrap one layer of this at a time.