### PR TITLE
One visit

### DIFF
--- a/api/V1/Visits.ts
+++ b/api/V1/Visits.ts
@@ -30,7 +30,6 @@ interface AnimalMap {
 // highest occurence that isnt unidentified
 function getRecordingTag(tracks: any[], userID: number): TrackTag | null {
   const animalVote = {};
-  let maxVote = null;
   for (const track of tracks) {
     const tag = getTrackTag(track.TrackTags, userID);
     if (tag) {
@@ -39,19 +38,18 @@ function getRecordingTag(tracks: any[], userID: number): TrackTag | null {
       } else {
         animalVote[tag.what] = { tag: tag, count: 1 };
       }
-      if (
-        (maxVote == null || maxVote.count < animalVote[tag.what].count) &&
-        tag.what != unidentified
-      ) {
-        maxVote = animalVote[tag.what];
-      }
     }
   }
+  const sortedKeys = Object.keys(animalVote).sort(function (a, b) {
+    if (a == unidentified) {
+      return 1;
+    }
+    return animalVote[b].count - animalVote[a].count;
+  });
+
+  const maxVote = animalVote[sortedKeys[0]];
   if (maxVote) {
     return maxVote.tag;
-  }
-  if (unidentified in animalVote) {
-    return animalVote[unidentified].tag;
   }
   return null;
 }

--- a/api/V1/Visits.ts
+++ b/api/V1/Visits.ts
@@ -26,6 +26,27 @@ interface AnimalMap {
   [key: string]: VisitSummary;
 }
 
+function getRecordingTag(tracks:any [], userID: number): any | null{
+  animalVote = {}
+  let max = null;
+  for(const track of tracks){
+    const tag = getTrackTag(track.TrackTags, userId)
+    if (tag && tag.what != unidentified) {
+        if(tag in animalVote){
+          animalVote[tag.what] +=1
+        }else{
+          animalVote[tag.what] = 1
+        }
+        if(max == null || max[0] < animalVote[tag.what]){
+          max = [animalVote[tag.what], tag, track]
+        }
+    }
+  }
+  if(max){
+    return max[1]
+  }
+  return null;
+}
 // getTrackTag from all tags return a single tag by precedence:
 // this users tag, or any other humans tag, else the original AI
 function getTrackTag(trackTags: TrackTag[], userID: number): TrackTag | null {
@@ -221,9 +242,9 @@ class DeviceVisits {
 
     const tracks = rec.Tracks;
     this.sortTracks(tracks);
-
-    for (const track of tracks) {
-      const event = this.calculateTrackTagEvent(rec, track);
+    const trackTags = getRecordingTag(tracks, this.userID)
+    for (const trackTag of trackTags) {
+      const event = this.calculateTrackTagEvent(rec, trackTag.track, trackTag.tag);
       if (event == null) {
         continue;
       }
@@ -269,13 +290,9 @@ class DeviceVisits {
   // otherwise it will add an event to an existing visit and return the new event
   calculateTrackTagEvent(
     rec: Recording,
-    track: any
+    track: any,
+    tag: TrackTag
   ): null | Visit | VisitEvent {
-    const tag = getTrackTag(track.TrackTags, this.userID);
-    if (!tag) {
-      return null;
-    }
-
     const trackPeriod = new TrackStartEnd(rec, track);
     if (this.unknownIsPartOfPreviousVisit(tag, trackPeriod.trackEnd)) {
       return this.addEventToPreviousVisit(rec, track, tag);

--- a/api/V1/Visits.ts
+++ b/api/V1/Visits.ts
@@ -363,7 +363,7 @@ class DeviceVisits {
     if (unVisit && unVisit.what == unidentified) {
       let unEvent = unVisit.events[unVisit.events.length - 1];
       while (unEvent && isWithinVisitInterval(visit.end, unEvent.start)) {
-        unEvent.wasTaggedAs = unidentified;
+        unEvent.assumedTag = visit.what;
         visit.addEventAtIndex(unEvent, 0);
         unVisit.removeEventAtIndex(unVisit.events.length - 1);
         unEvent = unVisit.events[unVisit.events.length - 1];
@@ -564,7 +564,7 @@ class Visit {
 }
 
 class VisitEvent {
-  wasTaggedAs: string;
+  assumedTag: string;
   recID: number;
   recStart: Moment;
   trackID: number;
@@ -579,27 +579,21 @@ class VisitEvent {
     const trackTimes = new TrackStartEnd(rec, track);
     this.audioBaitDay = false;
     this.audioBaitVisit = false;
-    this.wasTaggedAs = null;
     this.recID = rec.id;
     this.audioBaitEvents = [];
     this.recStart = trackTimes.recStart;
     this.trackID = track.id;
-    this.what = tag.what;
-    if (tag.what != unidentified) {
-      this.confidence = Math.round(tag.confidence * 100);
-    } else {
-      this.confidence = 0;
-    }
+    this.what = taggedAs.what;
+    this.assumedTag = tag.what;
+    this.confidence = Math.round(tag.confidence * 100);
     this.start = trackTimes.trackStart;
     this.end = trackTimes.trackEnd;
 
-    if (tag.what != taggedAs.what) {
-      this.wasTaggedAs = taggedAs.what;
-    }
+
     this.setAudioBaitEvents(rec);
   }
   wasUnidentified() {
-    return this.wasTaggedAs == unidentified;
+    return this.what == unidentified;
   }
   setAudioBaitEvents(rec) {
     let events = rec.Device.Events;

--- a/api/V1/Visits.ts
+++ b/api/V1/Visits.ts
@@ -249,11 +249,12 @@ class DeviceVisits {
     const tracks = rec.Tracks;
     this.sortTracks(tracks);
     const recTag = getRecordingTag(tracks, this.userID);
-    if (recTag == null) return visits;
+    if (recTag == null) {
+      return visits;
+    }
 
     for (const track of tracks) {
       const tag = getTrackTag(track.TrackTags, this.userID);
-
       const event = this.calculateTrackTagEvent(rec, track, recTag, tag);
       if (event == null) {
         continue;
@@ -588,7 +589,6 @@ class VisitEvent {
     this.confidence = Math.round(tag.confidence * 100);
     this.start = trackTimes.trackStart;
     this.end = trackTimes.trackEnd;
-
 
     this.setAudioBaitEvents(rec);
   }

--- a/api/V1/Visits.ts
+++ b/api/V1/Visits.ts
@@ -565,6 +565,9 @@ class Visit {
 }
 
 class VisitEvent {
+  // this is the overriding tag that we have given this event
+  // e.g. if it was unidentified but grouped under a cat visit
+  // assumedTag woudl be "cat"
   assumedTag: string;
   recID: number;
   recStart: Moment;

--- a/models/Recording.ts
+++ b/models/Recording.ts
@@ -1033,7 +1033,7 @@ from (
               "TrackId",
               "confidence",
               "UserId",
-              [Sequelize.json("data.name"),"data"]
+              [Sequelize.json("data.name"), "data"]
             ],
             include: [
               {

--- a/test/test_visits.py
+++ b/test/test_visits.py
@@ -8,6 +8,42 @@ from dateutil.parser import parse as parsedate
 class TestVisits:
     VISIT_INTERVAL_SECONDS = 600
 
+    def test_multiple_animals(self, helper):
+        admin = helper.admin_user()
+        cosmo = helper.given_new_user(self, "cosmo")
+        cosmo_group = helper.make_unique_group_name(self, "cosmos_group")
+        cosmo.create_group(cosmo_group)
+        device = helper.given_new_device(self, "cosmo_device", cosmo_group)
+        now = datetime.now(dateutil.tz.gettz(helper.TIMEZONE)).replace(microsecond=0)
+
+        # check that a recording with 2 possums and 1 cat, assumes the cat is a possum
+        rec, _, _ = helper.upload_recording_with_tag(device, admin, "possum", time=now - timedelta(seconds=0))
+        track = admin.can_add_track_to_recording(rec, start_s=80)
+        admin.can_tag_track(track, what="possum")
+        track = admin.can_add_track_to_recording(rec, start_s=80)
+        admin.can_tag_track(track, what="cat")
+        response = cosmo.query_visits(return_json=True)
+        assert response["numVisits"] == 1
+        visit = response["rows"][str(device.get_id())]["visits"][0]
+        assert visit["what"] == "possum"
+        assert len(visit["events"]) == 3
+
+        device = helper.given_new_device(self, "cosmo_device2", cosmo_group)
+        # check that a recording with 2 unidentified and 1 cat, assumes the unidentified is a cat
+        rec, _, _ = helper.upload_recording_with_tag(
+            device, admin, "unidentified", time=now - timedelta(seconds=0)
+        )
+        track = admin.can_add_track_to_recording(rec, start_s=80)
+        admin.can_tag_track(track, what="unidentified")
+        track = admin.can_add_track_to_recording(rec, start_s=80)
+        admin.can_tag_track(track, what="cat")
+
+        response = cosmo.query_visits(return_json=True, deviceIds=device.get_id())
+        assert response["numVisits"] == 1
+        visit = response["rows"][str(device.get_id())]["visits"][0]
+        assert visit["what"] == "cat"
+        assert len(visit["events"]) == 3
+
     def test_visit_grouping(self, helper):
         admin = helper.admin_user()
         cosmo = helper.given_new_user(self, "cosmo")


### PR DESCRIPTION
Calculate a overriding a tag for all tracks in a recording.
This is done by tallying up the tags, and the tag with the highest count is assumed to be correct for all tracks.

Added assumedTag property to a VisitEvent, this refers to the overriding tag that this event has been given. 
E.g. it it was tagged as a cat but has been grouped under a possum visit, the assumedTag would be "possum" while tag would be "cat"