### PR TITLE
Fixed inconsistency in the event-type name checking.

### DIFF
--- a/api/V1/Event.ts
+++ b/api/V1/Event.ts
@@ -118,7 +118,7 @@ export default function (app: Application, baseUrl: string) {
       query("deviceId").isInt().optional().toInt(),
       query("offset").isInt().optional().toInt(),
       query("limit").isInt().optional().toInt(),
-      query("type").isAlpha().optional()
+      query("type").matches(eventUtil.EVENT_TYPE_REGEXP).optional()
     ],
     middleware.requestWrapper(async (request, response) => {
       const query = request.query;

--- a/api/V1/eventUtil.ts
+++ b/api/V1/eventUtil.ts
@@ -6,6 +6,8 @@ import responseUtil from "./responseUtil";
 import { body, oneOf } from "express-validator/check";
 import { groupSystemErrors } from "./systemError";
 
+const EVENT_TYPE_REGEXP = /^[A-Z0-9/-]+$/i;
+
 async function errors(request: any, admin?: boolean) {
   const query = request.query;
   let options = {} as QueryOptions;
@@ -73,14 +75,16 @@ const eventAuth = [
     "dateTimes",
     "List of times event occured is required."
   ),
+  body("description.type").matches(EVENT_TYPE_REGEXP).optional(), 
   oneOf(
     [body("eventDetailId").exists(), body("description.type").exists()],
-    "Either 'eventDetailId' or 'description.type' must be specified."
+    "Either 'eventDetailId' or 'description.type' must be specified.  Description"
   )
 ];
 
 export default {
   eventAuth,
   uploadEvent,
-  errors
+  errors, 
+  EVENT_TYPE_REGEXP
 };

--- a/test/test_event.py
+++ b/test/test_event.py
@@ -2,7 +2,7 @@ import pytest
 import json
 
 from datetime import datetime, timedelta, timezone
-from test.testexception import AuthorizationError
+from test.testexception import AuthorizationError, UnprocessableError
 
 
 class TestEvent:
@@ -28,17 +28,29 @@ class TestEvent:
         assert len(service["errors"]) == 2
         assert set(len(error["similar"]) for error in service["errors"]) == set([1, 2])
 
+    def test_cannot_create_event_type_with_funny_chars(self, helper):
+        not_doer = helper.given_new_device(self, "The dont doer")
+
+        with pytest.raises(UnprocessableError):
+            not_doer.record_event("Type with spaces", {"lure-id": "possum_screech"})
+
+        with pytest.raises(UnprocessableError):
+            not_doer.record_event("Type_with_underscores", {"lure-id": "possum_screech"})
+
+        with pytest.raises(UnprocessableError):
+            not_doer.record_event("Type with $", {"lure-id": "possum_screech"})
+
     def test_can_create_new_event(self, helper):
         doer = helper.given_new_device(self, "The Do-er")
-        new_event_name = "E_" + helper.random_id()
+        new_event_name = "E-" + helper.random_id()
 
-        screech = doer.record_event(new_event_name, {"lure_id": "possum_screech"})
-        screech2 = doer.record_event(new_event_name, {"lure_id": "possum_screech"})
+        screech = doer.record_event(new_event_name, {"lure-id": "possum_screech"})
+        screech2 = doer.record_event(new_event_name, {"lure-id": "possum_screech"})
 
         print("Then these events with the same details should use the same eventDetailId.")
         assert screech == screech2, "And events with the same details should use the same eventDetailId"
 
-        howl = doer.record_event(new_event_name, {"lure_id": "possum_howl"})
+        howl = doer.record_event(new_event_name, {"lure-id": "possum_howl"})
 
         print("Then the events with some different details should have different eventDetailIds.")
         assert screech != howl, "Events with different details should link to different eventDetailIds"
@@ -73,14 +85,14 @@ class TestEvent:
 
     def test_devices_share_events(self, helper):
         shaker = helper.given_new_device(self, "The Shaker")
-        new_event_name = "E_" + helper.random_id()
+        new_event_name = "E-" + helper.random_id()
 
-        sameDetails = shaker.record_event(new_event_name, {"lure_id": "possum_screech"})
+        sameDetails = shaker.record_event(new_event_name, {"lure-id": "possum_screech"})
 
         print("    and ", end="")
         actioner = helper.given_new_device(self, "Actioner")
 
-        sameDetailsDifferentDevice = actioner.record_event(new_event_name, {"lure_id": "possum_screech"})
+        sameDetailsDifferentDevice = actioner.record_event(new_event_name, {"lure-id": "possum_screech"})
 
         print("Then the devices should share the same eventDetailId.")
         assert (
@@ -93,7 +105,7 @@ class TestEvent:
         # check there are no events on this device
         fred.cannot_see_events()
 
-        freds_device.record_event("playLure", {"lure_id": "possum_screech"})
+        freds_device.record_event("playLure", {"lure-id": "possum_screech"})
 
         print("Then 'freddie' should be able to see that the device has an event")
         assert len(fred.can_see_events()) == 1
@@ -106,7 +118,7 @@ class TestEvent:
 
     def test_should_be_able_to_upload_several_events_at_same_time(self, helper):
         rocker = helper.given_new_device(self, "The Rocker")
-        detailId = rocker.record_event("playLure", {"lure_id": "possum_screecher"})
+        detailId = rocker.record_event("playLure", {"lure-id": "possum_screecher"})
         rocker.record_three_events_at_once(detailId)
         print("And super users should be able to see get all four events for the device")
         assert len(helper.admin_user().can_see_events(rocker)) == 4
@@ -114,15 +126,15 @@ class TestEvent:
     def test_get_event_attributes_returned(self, helper):
         boombox = helper.given_new_device(self, "boombox")
         description = "E_" + helper.random_id()
-        boombox.record_event("audio-bait-played", {"lure_id": "possum_screams", "description": description})
+        boombox.record_event("audio-bait-played", {"lure-id": "possum_screams", "description": description})
         event = helper.admin_user().can_see_events(boombox)[0]
         print("Then get events returns an event")
         print("    with DeviceId = '{}'".format(boombox.get_id()))
         assert event["DeviceId"] == boombox.get_id()
         print("    and EventDetail.type = 'audio-bait-played'")
         assert event["EventDetail"]["type"] == "audio-bait-played"
-        print("    and EventDetail.details.lure_id = 'possum_screems'")
-        assert event["EventDetail"]["details"]["lure_id"] == "possum_screams"
+        print("    and EventDetail.details.lure-id = 'possum_screems'")
+        assert event["EventDetail"]["details"]["lure-id"] == "possum_screams"
         print("    and EventDetail.details.description = '{}'".format(description))
         assert event["EventDetail"]["details"]["description"] == description
 
@@ -130,7 +142,7 @@ class TestEvent:
         fred, freds_device = helper.given_new_user_with_device(self, "freddie")
 
         now = datetime.now(tz=timezone.utc)
-        freds_device.record_event("playLure", {"lure_id": "possum_screech"}, [now])
+        freds_device.record_event("playLure", {"lure-id": "possum_screech"}, [now])
         assert len(fred.can_see_events()) == 1
 
         sec = timedelta(seconds=1)
@@ -156,20 +168,20 @@ class TestEvent:
     def test_event_filtering(self, helper):
         georgina, georgina_device = helper.given_new_user_with_device(self, "georgina")
 
-        georgina_device.record_event("playLure", {"lure_id": "possum_screech"})
+        georgina_device.record_event("play-Lure", {"lure-id": "possum_screech"})
         georgina_device.record_event("software", {"recorder": "v1.3"})
         assert len(georgina.can_see_events()) == 2
 
         assert georgina.gets_first_event(type="software")["type"] == "software"
 
-        assert georgina.gets_first_event(type="playLure")["type"] == "playLure"
+        assert georgina.gets_first_event(type="play-Lure")["type"] == "play-Lure"
 
     def test_latest_first(self, helper):
         lily, lily_device = helper.given_new_user_with_device(self, "lily")
 
-        lily_device.record_event("first_event", {"lure_id": "possum_screech"})
-        lily_device.record_event("second_event", {"recorder": "v1.3"})
+        lily_device.record_event("first-event", {"lure-id": "possum_screech"})
+        lily_device.record_event("second-event", {"recorder": "v1.3"})
 
-        assert "first_event" == lily.gets_first_event()["type"]
+        assert "first-event" == lily.gets_first_event()["type"]
 
-        assert "second_event" == lily.gets_first_event(latest="true")["type"]
+        assert "second-event" == lily.gets_first_event(latest="true")["type"]


### PR DESCRIPTION
The event api allowed event types with '-' in them and many events types have these spaces in them.  However the get events request didn't allow anything other than alpha characters.   This anomaly how now been fixed. 