### PR TITLE
check for null value, also add trackid to alert link

### DIFF
--- a/api/V1/recordingUtil.ts
+++ b/api/V1/recordingUtil.ts
@@ -249,7 +249,7 @@ async function reportRecordings(request: RecordingQuery) {
   const audioFileIds: Set<number> = new Set();
   for (const r of result) {
     const event = findLatestEvent(r.Device.Events);
-    if (event) {
+    if (event && event.EventDetail) {
       const fileId = event.EventDetail.details.fileId;
       audioEvents[r.id] = {
         timestamp: event.dateTime,

--- a/emailUtil.ts
+++ b/emailUtil.ts
@@ -10,15 +10,13 @@ function alertBody(
   tag: TrackTag,
   camera: String
 ): string[] {
-  const dateTime = moment(recording.recordingDateTime)
-    .tz(config.timeZone)
-    .format("h:mma Do MMM");
+  const dateTime = moment(recording.recordingDateTime).format(" H:MMa Do MMM");
   let html = `<h1>${camera} has detected a ${tag.what} - ${dateTime}</h1>`;
-  html += `<a  href="${config.server.recording_url_base}/${recording.id}?device=${recording.DeviceId}">View Recording</a>`;
+  html += `<a  href="${config.server.recording_url_base}/${recording.id}/${tag.TrackId}?device=${recording.DeviceId}">View Recording</a>`;
   html += "<br><p>Thanks,<br> Cacophony Team</p>";
 
-  let text = `${camera} has detected a ${tag.what} - ${dateTime}\r\n`;
-  text += `Go to ${config.server.recording_url_base}/${recording.id}?device=${recording.DeviceId} to view this recording\r\n`;
+  let text = `${camera} has detected a ${tag.what} - ${dateTime}\n`;
+  text += `Go to ${config.server.recording_url_base}/${recording.id}/${tag.TrackId}?device=${recording.DeviceId} to view this recording\n`;
   text += "Thanks, Cacophony Team";
   return [html, text];
 }

--- a/emailUtil.ts
+++ b/emailUtil.ts
@@ -12,13 +12,13 @@ function alertBody(
 ): string[] {
   const dateTime = moment(recording.recordingDateTime)
     .tz(config.timeZone)
-    .format(" H:MMa Do MMM");
+    .format("h:mma Do MMM");
   let html = `<h1>${camera} has detected a ${tag.what} - ${dateTime}</h1>`;
   html += `<a  href="${config.server.recording_url_base}/${recording.id}/${tag.TrackId}?device=${recording.DeviceId}">View Recording</a>`;
   html += "<br><p>Thanks,<br> Cacophony Team</p>";
 
-  let text = `${camera} has detected a ${tag.what} - ${dateTime}\n`;
-  text += `Go to ${config.server.recording_url_base}/${recording.id}/${tag.TrackId}?device=${recording.DeviceId} to view this recording\n`;
+  let text = `${camera} has detected a ${tag.what} - ${dateTime}\r\n`;
+  text += `Go to ${config.server.recording_url_base}/${recording.id}/${tag.TrackId}?device=${recording.DeviceId} to view this recording\r\n`;
   text += "Thanks, Cacophony Team";
   return [html, text];
 }

--- a/emailUtil.ts
+++ b/emailUtil.ts
@@ -10,7 +10,9 @@ function alertBody(
   tag: TrackTag,
   camera: String
 ): string[] {
-  const dateTime = moment(recording.recordingDateTime).format(" H:MMa Do MMM");
+  const dateTime = moment(recording.recordingDateTime)
+    .tz(config.timeZone)
+    .format(" H:MMa Do MMM");
   let html = `<h1>${camera} has detected a ${tag.what} - ${dateTime}</h1>`;
   html += `<a  href="${config.server.recording_url_base}/${recording.id}/${tag.TrackId}?device=${recording.DeviceId}">View Recording</a>`;
   html += "<br><p>Thanks,<br> Cacophony Team</p>";

--- a/models/Recording.ts
+++ b/models/Recording.ts
@@ -799,9 +799,7 @@ from (
   };
 
   /* eslint-disable indent */
-  Recording.prototype.getActiveTracksTagsAndTagger = async function (): Promise<
-    any
-  > {
+  Recording.prototype.getActiveTracksTagsAndTagger = async function (): Promise<any> {
     return await this.getTracks({
       where: {
         archivedAt: null

--- a/models/TrackTag.ts
+++ b/models/TrackTag.ts
@@ -19,12 +19,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import Sequelize from "sequelize";
 import { ModelCommon, ModelStaticCommon } from "./index";
 import { UserId as UserIdAlias } from "./User";
-
+import { TrackId } from "./Track";
 export const AI_MASTER = "Master";
 export type TrackTagId = number;
+
 export interface TrackTag extends Sequelize.Model, ModelCommon<TrackTag> {
   isAdditionalTag: () => boolean;
   id: TrackTagId;
+  TrackId: TrackId;
   what: string;
   automatic: boolean;
   UserId: UserIdAlias;


### PR DESCRIPTION
Previous change to remove EventDetail as a requirement from sequelize join (to speed up query) broke the if statement as previously checking just for event was enough to ensure eventdetail also existed.